### PR TITLE
fix #12 記事の編集削除機能実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -23,6 +23,24 @@ class ArticlesController < ApplicationController
     @article = Article.find(params[:id])
   end
 
+  def edit
+    @article = current_user.articles.find(params[:id])
+  end
+
+  def update
+    @article = current_user.articles.find(params[:id])
+    if @article.update(article_params)
+      redirect_to article_path(@article)
+    end
+  end
+
+
+  def destroy
+    @article = current_user.articles.find(params[:id])
+    @article.destroy!
+    redirect_to articles_path
+  end
+
   private
 
   def article_params

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,0 +1,15 @@
+<div class= "bg-white">
+  <div class= "w-5/6 mx-auto max-w-screen-xl">
+    <div class="text-xl flex justify-center h-screen w-full"> 
+      <div class="w-full h-full flex flex-col">
+        <%= form_with model: @article do |form| %>
+          <%= form.label :title, "タイトル", class: "bg-white text-gray-600" %>
+          <%= form.text_field :title, placeholder: 'タイトル', class: 'bg-white text-gray-600 textarea textarea-bordered mb-4 w-full'%>
+          <br>
+          <%= form.label :body, "本文", class: "bg-white text-gray-600"%>
+          <%= form.text_area :body, placeholder: '本文', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
+          <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+        <% end %>
+      </div>
+  </div>
+</div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -5,6 +5,11 @@
       <h2 class="text-base mt-5 flex justify-center"><%=l @article.created_at, format: :long %></h2>
       <h3 class="flex justify-center mt-10 bg-white"><%= @article.body %></h3>
   </div>
-
-</div>
+  <div class= "flex justify-center gap-7 mb-10 mt-10">
+    <% if @article.user == current_user %>
+      <%=link_to '編集', edit_article_path(@article), class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+      <%=link_to '削除', article_path(@article), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' }, class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+    <% end %>
+  </div>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   root 'staticpages#top'
   resources :users, only: [:new, :create]
-  resources :articles, only: [:index, :new, :create, :show]
+  resources :articles
   
   get 'login' => 'usersessions#new', :as => :login
   post 'login' => "usersessions#create"


### PR DESCRIPTION
## チケットへのリンク
close #12 

## やったこと
- 現在ログインしているユーザーの投稿のみ、編集削除ボタンが表示されること
- 編集削除ボタンが機能するよう実装

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 記事の編集、削除ができるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- ローカル / 本番環境：現在ログインしているユーザーが、記事を編集削除できることを確認

## その他
- 特になし