### PR TITLE
fix #18 記事の検索機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 gem 'sorcery'
 gem 'rails-i18n'
+gem 'ransack'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,10 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
+    ransack (4.1.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -301,6 +305,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n
+  ransack
   selenium-webdriver
   sorcery
   sprockets-rails

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,8 +1,10 @@
 class ArticlesController < ApplicationController
   skip_before_action :require_login, only: [:index, :show]
   before_action :set_article, only: [:edit, :update, :destroy]
+
   def index
-    @articles = Article.includes(:user).all
+    @q = Article.ransack(params[:q])
+    @articles = @q.result(distinct: true).includes(:user).order(created_at: :desc)
   end
 
   def new

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -16,4 +16,16 @@ class Article < ApplicationRecord
   def favorite?
     favorites.exists?
   end
+
+  # name_cont追加時に追加
+  def self.ransackable_attributes(auth_object = nil)
+    ["body", "created_at", "id", "id_value", "title", "updated_at", "user_id"]
+  end
+
+  # name_cont追加時に追加
+  def self.ransackable_associations(auth_object = nil)
+    ["favorites", "user"]
+  end
+    
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,14 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+
+  # userモデルのカラムが使えるよう指定
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "crypted_password", "email", "id", "id_value", "name", "salt", "updated_at"]
+  end
+
+  # title_or_body_cont追加時に追加
+  def self.ransackable_associations(auth_object = nil)
+    ["articles", "favorites"]
+  end
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,5 +1,11 @@
 <div class= "bg-white">
   <div class= "w-5/6 mx-auto max-w-screen-xl">
+  <div class="text-lg flex justify-center">
+    <%= search_form_for @q do |f| %>
+    <%= f.search_field :user_name_or_title_or_body_cont, class: "text-black bg-white input input-bordered" %>
+    <%= f.submit '検索', class: "text-gray-600 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+    <% end %>
+  </div>
   <div class= "grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
     <% if @articles.present? %>
       <% @articles.each do |article| %>


### PR DESCRIPTION
## チケットへのリンク
close #18 

## やったこと
- 一覧画面で、「記事のタイトル、投稿、投稿者名」の曖昧検索ができるよう実装した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 記事の中から、読みたい記事を検索できるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- - ローカル / 本番環境：両環境ともに、「記事のタイトル、投稿、投稿者名」の曖昧検索ができることを確認

## その他
- 特になし