### PR TITLE
fix #10 記事のマークダウン化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem "bootsnap", require: false
 gem 'sorcery'
 gem 'rails-i18n'
 gem 'ransack'
+gem 'kramdown'
+gem 'kramdown-parser-gfm'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,10 @@ GEM
       railties (>= 6.0.0)
     jwt (2.8.2)
       base64
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -301,6 +305,8 @@ DEPENDENCIES
   debug
   jbuilder
   jsbundling-rails
+  kramdown
+  kramdown-parser-gfm
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link kramdown_custom.css

--- a/app/assets/stylesheets/kramdown_custom.css
+++ b/app/assets/stylesheets/kramdown_custom.css
@@ -1,0 +1,107 @@
+h1 {
+    font-size: 1.65em; 
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+}
+
+h2 {
+    font-size: 1.5em; 
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+}
+
+h3 {
+    font-size: 1.17em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
+h4 {
+    font-size: 1.12em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
+h5 {
+    font-size: 0.83em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
+h6 {
+    font-size: 0.75em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
+pre {
+    background-color: #f5f5f5;  /* 背景色 */
+    padding: 10px;              /* 内側の余白 */
+    border-radius: 5px;         /* 角の丸み */
+    border: 1px solid #ddd;     /* 枠線 */
+    overflow: auto;             /* オーバーフロー時にスクロール */
+}
+
+code {
+    background-color: #f5f5f5;
+    padding: 2px 4px;
+    border-radius: 4px;
+}
+
+blockquote {
+    background-color: #f9f9f9; /* 背景色 */
+    border-left: 5px solid #ccc; /* 左側のボーダー */
+    margin: 1.5em 10px; /* 外側の余白 */
+    padding: 0.5em 10px; /* 内側の余白 */
+    quotes: "“" "”" "‘" "’";
+}
+
+blockquote p {
+    display: inline; /* ブロック内の段落をインライン表示 */
+}
+
+body hr {
+    border: 0;
+    border-top: 1px solid #ccc;
+    margin: 1em 0;
+}
+
+/* 番号付きリストのスタイル */
+ol {
+    list-style-type: decimal;
+    margin: 0;
+    padding: 0 0 0 2em;
+}
+
+ol li {
+    margin: 0.5em 0;
+}
+
+link {
+    border-bottom: currentColor 1px solid
+}
+
+/* テーブルのスタイル */
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1em 0;
+    border: 1px solid #ddd;
+}
+
+table th, table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+
+table th {
+    background-color: #f2f2f2;
+}
+
+hr {
+    height: 2px;
+    background-color: rgb(100, 98, 98);
+    width: 100%;
+    border: none;
+   }

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -15,7 +15,7 @@ class ArticlesController < ApplicationController
     @article = current_user.articles.build(article_params)
 
     if @article.save
-      redirect_to articles_path
+      redirect_to article_path(@article)
     else
       render :new
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def render_markdown(text)
+    Kramdown::Document.new(text, input: 'GFM').to_html
+  end
 end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,7 +1,7 @@
 
       <h1 class="text-3xl mt-5 flex justify-center"><%= @article.title %></h1>
       <h2 class="text-base mt-5 flex justify-center"><%=l @article.created_at, format: :long %></h2>
-      <h3 class="flex justify-center mt-10 bg-white"><%= @article.body %></h3>
+      <h3 class="mt-10 bg-white"><%= render_markdown(@article.body).html_safe %></h3>
 
 
   <div class= "flex justify-center gap-7 mb-10 mt-10">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,10 @@
     <!--bootstrapアイコン-->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <!--bootstrapアイコン-->
-    
+
+    <!--app/assets/stylesheets/kramdown_custom.cssを読み込む-->
+    <%= stylesheet_link_tag 'kramdown_custom', media: 'all' %>
+     <!--app/assets/stylesheets/kramdown_custom.cssを読み込む-->
   </head>
 
   <body>


### PR DESCRIPTION
## チケットへのリンク
close #10 

## やったこと
- 記事を投稿すると、マークダウン記法で出力した内容がHTML へ変換するよう実装
- 記事を投稿した際の遷移先を、記事詳細画面へ変更

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 記事内容がマークダウンで出力されるため、他の技術記事サイトと同様の書き方ができるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：マークダウン記法で出力されていることを確認。
- 一部マークダウン記法が適用されていないものがあるので、チケット #54 で確認する。

## その他
- 特になし