### PR TITLE
fix #17 プレビュー画面実装

### DIFF
--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -7,10 +7,22 @@
           <%= form.text_field :title, placeholder: 'タイトル', class: 'bg-white text-gray-600 textarea textarea-bordered mb-4 w-full'%>
           <br>
           <%= form.label :body, "本文", class: "bg-white text-gray-600" %>
-          <%= form.text_area :body, placeholder: '本文', class: "bg-white text-gray-600 textarea textarea-bordered w-full mb-4 h-full" %>
+          <%= form.text_area :body, id: "markdown", placeholder: '本文', class: "bg-white text-gray-600 textarea textarea-bordered w-full mb-4 h-full" %>
+          <div id="html"></div>
           <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
         <% end %>
       </div>
     </div>
   </div>
 </div>
+<script>
+  // idが「markdown」の要素を取得。ユーザーが入力を行ったときに以下の関数が実行される。
+  document.getElementById('markdown').addEventListener('input', function () {
+      // ユーザーが入力したMarkdownの内容を取得。
+      const markdown = document.getElementById('markdown').value;
+      // 取得したMarkdownをHTMLに変換。
+      const html = marked.parse(markdown);
+      // idが「html」の要素に変換したHTMLを表示。
+      document.getElementById('html').innerHTML = html;
+  });
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,11 @@
     <!--app/assets/stylesheets/kramdown_custom.cssを読み込む-->
     <%= stylesheet_link_tag 'kramdown_custom', media: 'all' %>
      <!--app/assets/stylesheets/kramdown_custom.cssを読み込む-->
+
+     <!--markedjsのCDN読み込み-->
+     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+     <!--markedjsのCDN読み込み-->
+
   </head>
 
   <body>


### PR DESCRIPTION
## チケットへのリンク
close #17 

## やったこと
- ユーザーが投稿した内容が、その場でリアルプレビューされるよう実装。

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- ユーザーが入力している内容がその場でリアルプレビューされるので、投稿完了されるまであっているか確認する心配がない。

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- - ローカル / 本番環境：ユーザーが入力している内容がその場でリアルプレビューされることを確認。

## その他
- 特になし