### PR TITLE
fix #58 コメント編集削除機能の実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,11 @@
 class CommentsController < ApplicationController
+  before_action :set_comment, only: [:edit, :update, :destroy]
+  def index
+    @comment = Comment.new
+  end
+
   def create
-    @comment = current_user.comments.build(comment_params)
+    @comment = current_user.comments.build(create_comment_params)
     @comment.save
     redirect_to article_path(@comment.article_id)
   end
@@ -9,10 +14,31 @@ class CommentsController < ApplicationController
     @comment = Comment.find(params[:id])
   end
 
+  def edit; end
+
+  def update
+    if @comment.update(update_comment_params)
+      redirect_to article_url
+    end
+  end
+
+  def destroy
+    @comment.destroy!
+    redirect_to article_path(@comment.article_id)
+  end
+  
+
   private
 
-  def comment_params
+  def create_comment_params
     params.require(:comment).permit(:body).merge(article_id: params[:article_id])
   end
 
+  def update_comment_params
+    params.require(:comment).permit(:body)
+  end
+
+  def set_comment
+    @comment = current_user.comments.find(params[:id])
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
-  belongs_to :article
+  belongs_to :article, optional: true
 
   validates :body, presence: true
 end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -46,3 +46,4 @@
 
 <%= render 'comments/form', comment: @comment, article: @article %>
 <%= render @article.comments %>
+

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,2 +1,7 @@
 <%= comment.user.name %>
 <%= comment.body %>
+
+<% if comment.user == current_user %>
+<%=link_to '編集', edit_comment_path(comment), class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+<%=link_to '削除', comment_path(comment), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' }, class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+<% end %>

--- a/app/views/comments/destroy.html.erb
+++ b/app/views/comments/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Comments#destroy</h1>
-<p>Find me in app/views/comments/destroy.html.erb</p>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,2 +1,5 @@
-<h1>Comments#edit</h1>
-<p>Find me in app/views/comments/edit.html.erb</p>
+<%= form_with model: @comment, url: comment_path(@comment) do |form| %>
+  <%= form.label :body, "コメント"%>
+  <%= form.text_area :body, placeholder: 'コメント', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
+  <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :users, only: [:new, :create]
   resources :articles do
     resources :favorites, only: [:create, :destroy]
-    resources :comments, only: [:create, :show], shallow: true
+    resources :comments, shallow: true
   end
   
   get 'login' => 'usersessions#new', :as => :login


### PR DESCRIPTION
## チケットへのリンク
close #58 

## やったこと
- コメント内容を編集削除できるように実装した

## やらないこと
**別チケットで対応すること**
- 編集削除機能の非同期処理
- 編集遷移先をその場する

## できるようになること（ユーザ目線）
- コメント内容を編集削除できるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- - ローカル / 本番環境：上記のやらないことを除き、編集削除ができていることは確認した

## その他
- 特になし