### PR TITLE
fix #24 プロフィール画面の実装

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,25 @@
+class ProfilesController < ApplicationController
+  before_action :set_user, only: [:edit, :update]
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to profile_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :commentfavorites, dependent: :destroy
+  has_one :profile
 
   validates :name, presence: true, length: { maximum: 10 }
   validates :email, uniqueness: true, presence: true

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,13 @@
+<%= form_with model: @user, url: profile_path do |form| %>
+  <%= form.label :email, "メールアドレス", class: 'block text-sm font-medium leading-6 text-gray-900' %>
+    <div class="mb-2">
+      <%= form.email_field :email, required: true, class: "bg-white block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"%>
+    </div>
+  <%= form.label :name, '名前', class: 'text-sm font-medium leading-6 text-gray-900' %>
+    <div class="mb-2">
+      <%= form.text_field :name, required: true, class: 'bg-white white w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6' %>
+    </div>
+  <%= form.submit '更新', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+<% end %>
+
+

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,6 @@
+<h1>プロフィール</h1>
+<p>メールアドレス</p>
+<%= current_user.email %>
+<p>氏名</p>
+<%= current_user.name %>
+<%= link_to '編集', edit_profile_path %>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -6,8 +6,9 @@
       <% end %>
     </div>
     <div class="lg:flex lg:gap-x-12 font-biz items-center">
-      <%= link_to '記事を投稿', new_article_path, class: "text-sm font-semibold leading-6 text-slate-200" %>
+      <%= link_to "記事を投稿", new_article_path, class: "text-sm font-semibold leading-6 text-slate-200" %>
       <%= link_to "記事を閲覧", articles_path, class: "text-sm font-semibold leading-6 text-slate-200" %>
+      <%= link_to "プロフィール", profile_path, class: "text-sm font-semibold leading-6 text-slate-200" %>
     </div>
     <div class="lg:flex lg:flex-1 lg:justify-end font-biz items-center">
       <%= link_to 'ログアウト', :logout, data: { turbo_method: :delete }, class: 'text-sm font-semibold leading-6 text-slate-200' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,14 @@
 Rails.application.routes.draw do
+  get 'profiles/edit'
+  get 'profiles/show'
+  get 'profiles/update'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   root 'staticpages#top'
   resources :users, only: [:new, :create]
+  resource :profile, only: [:edit, :show, :update]
 
   resources :articles do
     resources :favorites, only: [:create, :destroy]

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  test "should get edit" do
+    get profiles_edit_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get profiles_show_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get profiles_update_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## チケットへのリンク
close #24 

## やったこと
- ユーザーのメールアドレス、名前を更新できるようプロフィール画面を実装した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- ユーザーが新規登録をした後でも、ユーザー名、メールアドレスを変更できるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：ユーザー名、メールアドレスが変更できるようになった

## その他
- 特になし