### PR TITLE
fix #27 下書き、投稿済記事の閲覧

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,11 @@ class UsersController < ApplicationController
     end
   end
 
+  def my_articles
+    @draft_articles = current_user.articles.draft
+    @published_articles = current_user.articles.published
+  end
+
   private
 
   def user_params

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,6 +6,8 @@ class Article < ApplicationRecord
   validates :title, presence: true
   validates :body, presence: true
 
+  enum status: { draft: 0, published: 1 }
+
   def created_by?(user)
     return true if user_id == user.id
   end
@@ -13,8 +15,6 @@ class Article < ApplicationRecord
   def favorited?(user, type)
     favorites.where(user_id: user.id, favorite_type: type).exists?
   end
-
-  
 
   # name_cont追加時に追加
   def self.ransackable_attributes(auth_object = nil)
@@ -25,7 +25,4 @@ class Article < ApplicationRecord
   def self.ransackable_associations(auth_object = nil)
     ["favorites", "user"]
   end
-    
-  
-
 end

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -8,8 +8,15 @@
           <br>
           <%= form.label :body, "本文", class: "bg-white text-gray-600"%>
           <%= form.text_area :body, placeholder: '本文', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
-          <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+          <%= form.submit "投稿する", name: 'published', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+          <% end %>
+
+          <% if @article.draft? %>
+          <%= form_with model: @article do |form| %>
+          <%= form.submit "下書きする", name: 'draft', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+          <% end %>
         <% end %>
       </div>
+    </div>
   </div>
 </div>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -9,8 +9,9 @@
           <%= form.label :body, "本文", class: "bg-white text-gray-600" %>
           <%= form.text_area :body, id: "markdown", placeholder: '本文', class: "bg-white text-gray-600 textarea textarea-bordered w-full mb-4 h-full" %>
           <div id="html"></div>
-          <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
-        <% end %>
+          <%= form.submit "投稿する", name: 'published', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+          <%= form.submit "下書きする", name: 'draft', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+      <% end %>
       </div>
     </div>
   </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,3 +4,4 @@
 <p>氏名</p>
 <%= current_user.name %>
 <%= link_to '編集', edit_profile_path %>
+

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -20,8 +20,7 @@
   </div>
   <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
     <li><a><%= link_to "マイページ", profile_path, class: "text-sm font-semibold leading-6 text-slate-200" %></a></li>
-    <li><a>投稿済の記事</a></li>
-    <li><a>下書きの記事</a></li>
+    <li><a><%= link_to "記事", my_articles_users_path, class: "text-sm font-semibold leading-6 text-slate-200" %></a></li>
     <li><a>いいねした記事</a></li>
     <li><a><%= link_to 'ログアウト', :logout, data: { turbo_method: :delete }, class: 'text-sm font-semibold leading-6 text-slate-200' %></a></li>
   </ul>

--- a/app/views/users/my_articles.html.erb
+++ b/app/views/users/my_articles.html.erb
@@ -1,0 +1,22 @@
+<h1>下書き記事</h1>
+<ul>
+  <% @draft_articles.each do |article| %>
+  <div class="p-4 border rounded-lg">
+    <li>
+      <%= link_to article.title, article %>
+    </li>
+  <% end %>
+</ul>
+</div>
+</div>
+
+<h1>投稿済記事</h1>
+<ul>
+  <% @published_articles.each do |article| %>
+  <div class="p-4 border rounded-lg mb-3">
+    <li>
+      <%= link_to article.title, article %>
+    </li>
+  </div>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,12 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   root 'staticpages#top'
-  resources :users, only: [:new, :create]
+  resources :users, only: [:new, :create] do
+    collection do
+      get :my_articles
+    end
+  end
+
   resource :profile, only: [:edit, :show, :update]
 
   resources :articles do

--- a/db/migrate/20240704080051_add_status_to_articles.rb
+++ b/db/migrate/20240704080051_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :articles, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_04_005018) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_04_080051) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_005018) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 


### PR DESCRIPTION
## チケットへのリンク
close #27 

## やったこと
- マイページ上で、「下書き済記事」「投稿済記事」を見れるようにした

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 下書きした記事、投稿した記事を見れるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- - ローカル / 本番環境：現在ログインしているユーザーの下書きした記事、投稿した記事を、マイページ上から見れるようになった

## その他
- 特になし