### PR TITLE
fix #20 ソート機能の追加

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,8 +3,16 @@ class ArticlesController < ApplicationController
   before_action :set_article, only: [:edit, :update, :destroy]
 
   def index
-    @q = Article.ransack(params[:q])
-    @articles = @q.result(distinct: true).includes(:user).order(created_at: :desc).published
+    if params[:latest]
+      @q = Article.ransack(params[:q])
+      @articles = @q.result(distinct: true).includes(:user).published.latest
+    elsif params[:old]
+      @q = Article.ransack(params[:q])
+      @articles = @q.result(distinct: true).includes(:user).published.old
+    else
+      @q = Article.ransack(params[:q])
+      @articles = @q.result(distinct: true).includes(:user).published.shuffle
+    end
   end
 
   def new

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,6 +8,9 @@ class Article < ApplicationRecord
 
   enum status: { draft: 0, published: 1 }
 
+  scope :latest, -> {order(created_at: :desc)}
+  scope :old, -> {order(created_at: :asc)}
+
   def created_by?(user)
     return true if user_id == user.id
   end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -5,6 +5,10 @@
     <%= f.search_field :user_name_or_title_or_body_cont, class: "text-black bg-white input input-bordered" %>
     <%= f.submit '検索', class: "text-gray-600 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
     <% end %>
+
+    <%= link_to '新しい順', articles_path(latest: "true") %>
+    <%= link_to '古い順', articles_path(old: "true") %>
+
   </div>
   <div class= "grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
     <% if @articles.present? %>


### PR DESCRIPTION
## チケットへのリンク
close #20 

## やったこと
- 記事を一覧表示した際に、新しい順、古い順で見れるようソート機能を実装した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 記事を新しい順、古い順で見れるようになった

## できなくなること（ユーザ目線）
- 記事一覧のみを押した際には、ランダム表示されるようにしたため、デフォルトで新しい順を好むユーザーにとっては見にくい？

## 動作確認
- ローカル / 本番環境：両環境ともに、新しい順、古い順、ランダム表記になることを確認した

## その他
- 一覧ボタンを連続で押すと、少しブレる