### PR TITLE
fix #16 記事の下書き保存機能

### DIFF
--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -9,12 +9,12 @@
           <%= form.label :body, "本文", class: "bg-white text-gray-600"%>
           <%= form.text_area :body, placeholder: '本文', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
           <%= form.submit "投稿する", name: 'published', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
-          <% end %>
 
           <% if @article.draft? %>
           <%= form_with model: @article do |form| %>
           <%= form.submit "下書きする", name: 'draft', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
           <% end %>
+        <% end %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## チケットへのリンク
close #16 

## やったこと
- 記事の下書き保存機能を実装した
1, 記事を新規投稿する際に、「下書きする」「投稿する」ボタンを設置
2, 投稿した記事を編集する際は、「投稿する」ボタンのみ設置
3, 下書きに入れた記事を編集する場合は、「下書きする」「投稿する」ボタンを設置
4, 下書きを再度下書きにする場合は、投稿済記事等して表示されず、再度保存されることを確認

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 記事を途中で書いていても、記事を下書きに入れることができるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- - ローカル / 本番環境：両環境ともに、1-4で挙動することを確認した

## その他
- 特になし