### PR TITLE
update #23 パスワードリセット本番環境でのエラー対応

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,7 +88,7 @@ Rails.application.configure do
     password: ENV['GMAIL_PASSWORD'], #Gmailで設定したアプリパスワード
     authentication: :plain,
     enable_starttls_auto: true
-
+  }
 
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
## チケットへのリンク
close #23 

## やったこと
- パスワードを失念してしまったユーザーが、パスワードを再設定できるよう実装した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- パスワードを再設定できるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- - ローカル / 本番環境：両環境ともに、パスワードがリセットできることを確認した

## その他
- 特になし