### PR TITLE
fix #81 下書き投稿時の、いいねボタンとコメント欄の非表示化

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   skip_before_action :require_login, only: [:index, :show]
-  before_action :set_article, only: [:edit, :update, :destroy]
+  before_action :set_article, only: [:edit, :destroy]
 
   def index
     if params[:latest]
@@ -48,11 +48,12 @@ class ArticlesController < ApplicationController
   def edit; end
 
   def update
+    @article = current_user.articles.find(params[:id])
 
-    if params[:draft].present?
-      @article.status = :draft
-    else
+    if params[:published].present?
       @article.status = :published
+    else
+      @article.status = :draft
     end
 
     if @article.update(article_params)

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,16 +2,14 @@ class FavoritesController < ApplicationController
   def create
     @article = Article.find(params[:article_id])
     @favorite = current_user.favorites.new(article_id: params[:article_id], favorite_type: params[:type])
-    if @favorite.save
-      render :create
-    end
+    @favorite.save
+    redirect_to article_path(params[:article_id])
   end
 
   def destroy
     @article = Article.find(params[:article_id])
     @favorite = current_user.favorites.find_by(article_id: params[:article_id], favorite_type: params[:type])
-    if @favorite.destroy!
-      render :destroy
-    end
+    @favorite.destroy
+    redirect_to article_path(params[:article_id])
 end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,8 +3,10 @@ class Article < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  validates :title, presence: true
-  validates :body, presence: true
+  with_options if: :published? do
+    validates :title, presence: true
+    validates :body, presence: true
+  end
 
   # 記事の状態（下書きor投稿済）のステータス
   enum status: { draft: 0, published: 1 }

--- a/app/views/articles/_favorite.html.erb
+++ b/app/views/articles/_favorite.html.erb
@@ -1,0 +1,46 @@
+<!-------------１つ目のいいねボタン------------->
+<% if logged_in? %>
+  <% if @article.favorited?(current_user, :like_first) %>
+    <%= render 'articles/first_unfavorite', article: @article %>
+  <% else %>
+    <%= render 'articles/first_favorite', article: @article %>
+  <% end %>
+  <% end %>
+</div>
+<!-------------１つ目のいいねボタン------------->
+<!-------------２つ目のいいねボタン------------->
+<% if logged_in? %>
+  <% if @article.favorited?(current_user, :like_second) %>
+    <%= render 'articles/second_unfavorite', article: @article %>
+  <% else %>
+     <%= render 'articles/second_favorite', article: @article %>
+  <% end %>
+  <% end %>
+<!-------------２つ目のいいねボタン------------->
+<!-------------３つ目のいいねボタン------------->
+<% if logged_in? %>
+<% if @article.favorited?(current_user, :like_third) %>
+     <%= render 'articles/third_unfavorite', article: @article %>
+  <% else %>
+     <%= render 'articles/third_favorite', article: @article %>
+  <% end %>
+  <% end %>
+<!-------------３つ目のいいねボタン------------->
+<!-------------４つ目のいいねボタン------------->
+<% if logged_in? %>
+<% if @article.favorited?(current_user, :like_forth) %>
+    <%= render 'articles/forth_unfavorite', article: @article %>
+  <% else %>
+     <%= render 'articles/forth_favorite', article: @article %>
+  <% end %>
+  <% end %>
+<!-------------４つ目のいいねボタン------------->
+<!-------------５つ目のいいねボタン------------->
+<% if logged_in? %>
+<% if @article.favorited?(current_user, :like_fifth) %>
+    <%= render 'articles/fifth_unfavorite', article: @article %>
+  <% else %>
+     <%= render 'articles/fifth_favorite', article: @article %>
+  <% end %>
+  <% end %>
+<!-------------５つ目のいいねボタン------------->

--- a/app/views/articles/_fifth_favorite.html.erb
+++ b/app/views/articles/_fifth_favorite.html.erb
@@ -1,8 +1,8 @@
 <!-------------５つ目のいいねボタン------------->
 <div class="tooltip" data-tip="詳細をもっと知りたい">
-  <%= link_to article_favorites_path(@article.id, type: :like_fifth), data: { turbo_method: :post, turbo_stream: true }, class: "like-button-5", id: "fifth-favorite-#{@article.id}" do %>
+ <%= link_to article_favorites_path(article.id, type: :like_fifth), data: { turbo_method: :post }, class: "like-button-2" do %>
     <i class="bi bi-bell"></i>
-    <%= article.favorites.where(favorite_type: 'like_fifth').count %>
+    <%= @article.favorites.where(favorite_type: 'like_fifth').count %>
   <% end %>
 </div>
 <!-------------５つ目のいいねボタン------------->

--- a/app/views/articles/_fifth_unfavorite.html.erb
+++ b/app/views/articles/_fifth_unfavorite.html.erb
@@ -1,9 +1,8 @@
 <!-------------５つ目のいいねボタン------------->
 <div class="tooltip" data-tip="詳細をもっと知りたい">
-  <%= link_to article_favorite_path(article, @article.id, type: :like_fifth), data: { turbo_method: :delete }, class: "unlike-button-5", id: "fifth-unfavorite-#{@article.id}" do %>
+  <%= link_to article_favorite_path(article.id, type: :like_fifth), data: { turbo_method: :delete }, class: "unlike-button-2" do %>
     <i class="bi bi-bell-fill"></i>
-    <%= article.favorites.where(favorite_type: 'like_fifth').count %>
+    <%= @article.favorites.where(favorite_type: 'like_fifth').count %>
   <% end %>
 </div>
-  
 <!-------------５つ目のいいねボタン------------->

--- a/app/views/articles/_first_favorite.html.erb
+++ b/app/views/articles/_first_favorite.html.erb
@@ -1,8 +1,6 @@
 <!-------------１つ目のいいねボタン------------->
-<div class="tooltip" data-tip="参考になった！">
-  <%= link_to article_favorites_path(@article.id, type: :like_first), data: { turbo_method: :post, turbo_stream: true }, class: "like-button-1", id: "first-favorite-#{@article.id}" do %>
-    <i class="bi bi-arrow-through-heart"></i>
-    <%= article.favorites.where(favorite_type: 'like_first').count %>
-  <% end %>
-</div>
+<%= link_to article_favorites_path(@article.id, type: :like_first), data: { turbo_method: :post }, class: "like-button-1" do %>
+  <i class="bi bi-arrow-through-heart"></i>
+  <%= @article.favorites.where(favorite_type: 'like_first').count %>
+<% end %>
 <!-------------１つ目のいいねボタン------------->

--- a/app/views/articles/_first_unfavorite.html.erb
+++ b/app/views/articles/_first_unfavorite.html.erb
@@ -1,8 +1,8 @@
 <!-------------１つ目のいいねボタン------------->
 <div class="tooltip" data-tip="参考になった！">
-  <%= link_to article_favorite_path(article, @article.id, type: :like_first), data: { turbo_method: :delete }, class: "unlike-button-1" , id: "first-unfavorite-#{@article.id}" do %>
+  <%= link_to article_favorite_path(@article.id, type: :like_first), data: { turbo_method: :delete }, class: "unlike-button-1" do %>
     <i class="bi bi-arrow-through-heart-fill"></i>
-    <%= article.favorites.where(favorite_type: 'like_first').count %>
+    <%= @article.favorites.where(favorite_type: 'like_first').count %>
   <% end %>
 </div>
 <!-------------１つ目のいいねボタン------------->

--- a/app/views/articles/_forth_favorite.html.erb
+++ b/app/views/articles/_forth_favorite.html.erb
@@ -1,8 +1,8 @@
 <!-------------４つ目のいいねボタン------------->
 <div class="tooltip" data-tip="独自の視点！">
-  <%= link_to article_favorites_path(@article.id, type: :like_forth), data: { turbo_method: :post, turbo_stream: true }, class: "like-button-4", id: "forth-favorite-#{@article.id}" do %>
-<i class="bi bi-brightness-alt-high"></i>
-<%= article.favorites.where(favorite_type: 'like_forth').count %>
-<% end %>
+  <%= link_to article_favorites_path(article.id, type: :like_forth), data: { turbo_method: :post }, class: "like-button-2" do %>
+    <i class="bi bi-brightness-alt-high"></i>
+    <%= @article.favorites.where(favorite_type: 'like_forth').count %>
+  <% end %>
 </div>
 <!-------------４つ目のいいねボタン------------->

--- a/app/views/articles/_forth_unfavorite.html.erb
+++ b/app/views/articles/_forth_unfavorite.html.erb
@@ -1,8 +1,8 @@
 <!-------------４つ目のいいねボタン------------->
 <div class="tooltip" data-tip="独自の視点！">
-     <%= link_to article_favorite_path(article, @article.id, type: :like_forth), data: { turbo_method: :delete }, class: "unlike-button-4" , id: "forth-unfavorite-#{@article.id}" do %>
-       <i class="bi bi-brightness-alt-high-fill"></i>
-       <%= article.favorites.where(favorite_type: 'like_forth').count %>
-    <% end %>
+<%= link_to article_favorite_path(article.id, type: :like_forth), data: { turbo_method: :delete }, class: "unlike-button-2" do %>
+  <i class="bi bi-brightness-alt-high-fill"></i>
+  <%= @article.favorites.where(favorite_type: 'like_forth').count %>
+<% end %>
 </div>
 <!-------------４つ目のいいねボタン------------->

--- a/app/views/articles/_second_favorite.html.erb
+++ b/app/views/articles/_second_favorite.html.erb
@@ -1,8 +1,8 @@
 <!-------------２つ目のいいねボタン------------->
 <div class="tooltip" data-tip="学びが深まった">
-<%= link_to article_favorites_path(@article.id, type: :like_second), data: { turbo_method: :post, turbo_stream: true }, class: "like-button-2", id: "second-favorite-#{@article.id}" do %>
-  <i class="bi bi-award"></i>
-  <%= article.favorites.where(favorite_type: 'like_second').count %>
-<% end %>
+  <%= link_to article_favorites_path(article.id, type: :like_second), data: { turbo_method: :post }, class: "like-button-2" do %>
+    <i class="bi bi-award"></i>
+    <%= @article.favorites.where(favorite_type: 'like_second').count %>
+  <% end %>
 </div>
 <!-------------２つ目のいいねボタン------------->

--- a/app/views/articles/_second_unfavorite.html.erb
+++ b/app/views/articles/_second_unfavorite.html.erb
@@ -1,9 +1,10 @@
 <!-------------２つ目のいいねボタン------------->
 <div class="tooltip" data-tip="学びが深まった">
-  <%= link_to article_favorite_path(article, @article.id, type: :like_second), data: { turbo_method: :delete }, class: "unlike-button-2" , id: "second-unfavorite-#{@article.id}" do %> 
-  <i class="bi bi-award-fill"></i>
-  <%= @article.favorites.where(favorite_type: 'like_second').count %>
-<% end %>
+  <%= link_to article_favorite_path(article.id, type: :like_second), data: { turbo_method: :delete }, class: "unlike-button-2" do %>
+    <i class="bi bi-award-fill"></i>
+    <%= @article.favorites.where(favorite_type: 'like_second').count %>
+  <% end %>
 </div>
   
 <!-------------２つ目のいいねボタン------------->
+ 

--- a/app/views/articles/_third_favorite.html.erb
+++ b/app/views/articles/_third_favorite.html.erb
@@ -1,8 +1,8 @@
 <!-------------３つ目のいいねボタン------------->
 <div class="tooltip" data-tip="解説が丁寧">
-<%= link_to article_favorites_path(@article.id, type: :like_third), data: { turbo_method: :post, turbo_stream: true }, class: "like-button-3", id: "third-favorite-#{@article.id}" do %>
-<i class="bi bi-arrow-through-heart"></i>
-<%= article.favorites.where(favorite_type: 'like_third').count %>
-<% end %>
+  <%= link_to article_favorites_path(article.id, type: :like_third), data: { turbo_method: :post }, class: "like-button-2" do %>
+    <i class="bi bi-arrow-through-heart"></i>
+    <%= @article.favorites.where(favorite_type: 'like_third').count %>
+  <% end %>
 </div>
 <!-------------３つ目のいいねボタン------------->

--- a/app/views/articles/_third_unfavorite.html.erb
+++ b/app/views/articles/_third_unfavorite.html.erb
@@ -1,8 +1,8 @@
 <!-------------３つ目のいいねボタン------------->
 <div class="tooltip" data-tip="解説が丁寧">
-     <%= link_to article_favorite_path(article, @article.id, type: :like_third), data: { turbo_method: :delete }, class: "unlike-button-3" , id: "third-unfavorite-#{@article.id}" do %>
-       <i class="bi bi-arrow-through-heart-fill"></i>
-       <%= @article.favorites.where(favorite_type: 'like_third').count %>
-     <% end %>
+  <%= link_to article_favorite_path(article.id, type: :like_third), data: { turbo_method: :delete }, class: "unlike-button-2" do %>
+    <i class="bi bi-arrow-through-heart-fill"></i>
+    <%= @article.favorites.where(favorite_type: 'like_third').count %>
+  <% end %>
 </div>
 <!-------------３つ目のいいねボタン------------->

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -11,40 +11,13 @@
       <%=link_to '削除', article_path(@article), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' }, class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
     <% end %>
   </div>
+
+
+<% if @article.published? %>
 <div class= "flex justify-center gap-7 text-xl">
   <div class= "flex justify-center gap-7 text-xl">
-  <% if @article.favorited?(current_user, :like_first) %>
-    <%= render 'articles/first_unfavorite', article: @article %>
-    <% else %>
-    <%= render 'articles/first_favorite', article: @article %>
-   <% end %>
-
-   <% if @article.favorited?(current_user, :like_second) %>
-   <%= render 'articles/second_unfavorite', article: @article %>
-    <% else %>
-    <%= render 'articles/second_favorite', article: @article %>
-   <% end %>
-
-   <% if @article.favorited?(current_user, :like_third) %>
-   <%= render 'articles/third_unfavorite', article: @article %>
-    <% else %>
-    <%= render 'articles/third_favorite', article: @article %>
-   <% end %>
-
-   <% if @article.favorited?(current_user, :like_forth) %>
-   <%= render 'articles/forth_unfavorite', article: @article %>
-    <% else %>
-    <%= render 'articles/forth_favorite', article: @article %>
-   <% end %>
-
-   <% if @article.favorited?(current_user, :like_fifth) %>
-   <%= render 'articles/fifth_unfavorite', article: @article %>
-    <% else %>
-    <%= render 'articles/fifth_favorite', article: @article %>
-   <% end %>
-  </div>
-</div>
-
+<%= render 'articles/favorite', article: @article %>
 <%= render 'comments/form', comment: @comment, article: @article %>
 <%= render @article.comments, comment: @comment %>
+<% end %>
 

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,19 +1,29 @@
-<%= turbo_stream.replace "first-favorite-#{@article.id}", class: "like-button-1" do %>
+<% if @article.favorited?(current_user, :like_first) %>
+<%= turbo_stream.replace "first-favorite-#{@article.id}", class: "like-button-1" , type: :like_first do %>
   <%= render 'articles/first_unfavorite', article: @article %>
 <% end %>
+<% end %>
 
-<%= turbo_stream.replace "second-favorite-#{@article.id}", class: "like-button-2" do %>
+<% if @article.favorited?(current_user, :like_second) %>
+<%= turbo_stream.replace "second-favorite-#{@article.id}", class: "like-button-2", type: :like_first do %>
   <%= render 'articles/second_unfavorite', article: @article %>
 <% end %>
+<% end %>
 
-<%= turbo_stream.replace "third-favorite-#{@article.id}", class: "like-button-3" do %>
+<% if @article.favorited?(current_user, :like_third) %>
+<%= turbo_stream.replace "third-favorite-#{@article.id}", class: "like-button-3",  type: :like_third do %>
   <%= render 'articles/third_unfavorite', article: @article %>
 <% end %>
-
-<%= turbo_stream.replace "forth-favorite-#{@article.id}", class: "like-button-4" do %>
-  <%= render 'articles/forth_unfavorite', article: @article %>
 <% end %>
 
-<%= turbo_stream.replace "fifth-favorite-#{@article.id}", class: "like-button-5" do %>
+<% if @article.favorited?(current_user, :like_forth) %>
+<%= turbo_stream.replace "forth-favorite-#{@article.id}", class: "like-button-4", type: :like_forth do %>
+  <%= render 'articles/forth_unfavorite', article: @article %>
+<% end %>
+<% end %>
+
+<% if @article.favorited?(current_user, :like_fifth) %>
+<%= turbo_stream.replace "fifth-favorite-#{@article.id}", class: "like-button-5", type: :like_fifth do %>
   <%= render 'articles/fifth_unfavorite', article: @article %>
+<% end %>
 <% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,19 +1,29 @@
-<%= turbo_stream.replace "first-unfavorite-#{@article.id}", class: "unlike-button-1" do %>
+<% if @article.favorited?(current_user, :like_first) %>
+<%= turbo_stream.replace "first-unfavorite-#{@article.id}", class: "unlike-button-1", type: :like_first do %>
   <%= render 'articles/first_favorite', article: @article %>
 <% end %>
+<% end %>
 
-<%= turbo_stream.replace "second-unfavorite-#{@article.id}", class: "unlike-button-2" do %>
+<% if @article.favorited?(current_user, :like_second) %>
+<%= turbo_stream.replace "second-unfavorite-#{@article.id}", class: "unlike-button-2", type: :like_second do %>
   <%= render 'articles/second_favorite', article: @article %>
 <% end %>
+<% end %>
 
-<%= turbo_stream.replace "third-unfavorite-#{@article.id}" , class: "unlike-button-3" do %>
+<% if @article.favorited?(current_user, :like_third) %>
+<%= turbo_stream.replace "third-unfavorite-#{@article.id}", class: "unlike-button-3", type: :like_third do %>
   <%= render 'articles/third_favorite', article: @article %>
 <% end %>
-
-<%= turbo_stream.replace "forth-unfavorite-#{@article.id}", class: "unlike-button-4" do %>
-  <%= render 'articles/forth_favorite', article: @article %>
 <% end %>
 
-<%= turbo_stream.replace "fifth-unfavorite-#{@article.id}", class: "unlike-button-5" do %>
+<% if @article.favorited?(current_user, :like_forth) %>
+<%= turbo_stream.replace "forth-unfavorite-#{@article.id}", class: "unlike-button-4", type: :like_forth do %>
+  <%= render 'articles/forth_favorite', article: @article %>
+<% end %>
+<% end %>
+
+<% if @article.favorited?(current_user, :like_fifth) %>
+<%= turbo_stream.replace "fifth-unfavorite-#{@article.id}", class: "unlike-button-5", type: :like_fifth do %>
   <%= render 'articles/fifth_favorite', article: @article %>
+<% end %>
 <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "myapp_production"
 
   
-  config.action_mailer.default_url_options = { host: 'miniita.onrender.com', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: 'miniita.onrender.com', protocol: 'https', from: 'miniita.info@gmail.com' }
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
## チケットへのリンク
close #81 

## やったこと
- 下書き保存時、下書きを再度下書きに保存した際には、いいねボタンとコメント欄は表示されないよう条件分岐した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 下書き保存時には、いいね欄とコメント表示されないので下書きに保存していることがわかりやすい

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- ローカル / 本番環境：下書き保存時、下書きを再度下書きに保存した際には、いいねボタンとコメント欄は表示されないことを確認

## その他
- 特になし