### PR TITLE
fix #26 自分のいいねした記事画面の作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,8 +18,12 @@ class UsersController < ApplicationController
   end
 
   def my_articles
-    @draft_articles = current_user.articles.draft
-    @published_articles = current_user.articles.published
+    @draft_articles = current_user.articles.draft.includes(:user).order(created_at: :desc)
+    @published_articles = current_user.articles.published.includes(:user).order(created_at: :desc)
+  end
+
+  def my_favorites
+    @favorites = current_user.favorites.includes(:user).order(created_at: :desc)
   end
 
   private

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -14,7 +14,7 @@
     <% if @articles.present? %>
       <% @articles.each do |article| %>
       <div class="p-4 border rounded-lg">
-        <h2 class="text-xl mt-2 text-gray-600"><%= link_to article.title, article_path(article) %></h2> 
+        <h2 class="text-xl mt-2 text-gray-600"><%= link_to article.title, article_path(article)%></h2> 
         <h3 class="text-sm text-gray-600">作成日：<%= l article.created_at, format: :long %></h3>
         <h3 class="text-sm text-gray-600">更新日：<%= l article.updated_at, format: :long %></h3>
         <h3 class="text-sm text-gray-600"><%= article.user.name %></h3>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -20,8 +20,8 @@
   </div>
   <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
     <li><a><%= link_to "マイページ", profile_path, class: "text-sm font-semibold leading-6 text-slate-200" %></a></li>
-    <li><a><%= link_to "記事", my_articles_users_path, class: "text-sm font-semibold leading-6 text-slate-200" %></a></li>
-    <li><a>いいねした記事</a></li>
+    <li><a><%= link_to "自分の記事", my_articles_users_path, class: "text-sm font-semibold leading-6 text-slate-200" %></a></li>
+    <li><a><%= link_to "いいねした記事", my_favorites_users_path, class: "text-sm font-semibold leading-6 text-slate-200" %></a></li>
     <li><a><%= link_to 'ログアウト', :logout, data: { turbo_method: :delete }, class: 'text-sm font-semibold leading-6 text-slate-200' %></a></li>
   </ul>
 </div>

--- a/app/views/users/my_favorites.html.erb
+++ b/app/views/users/my_favorites.html.erb
@@ -1,0 +1,12 @@
+<h1>いいねした記事</h1>
+<ul>
+  <% @favorites.each do |favorite| %>
+  <div class="p-4 border rounded-lg mb-3">
+    <li>
+      <%=link_to favorite.article.title, article_path(favorite.article) %>
+    </li>
+    </div>
+  <% end %>
+</ul>
+</div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :users, only: [:new, :create] do
     collection do
       get :my_articles
+      get :my_favorites
     end
   end
 


### PR DESCRIPTION
## チケットへのリンク
close #26 

## やったこと
- マイページに、自分のいいねした記事が見れる項目を作成
- いいねした記事タイトルを押すと、その記事の詳細画面に遷移するよう実装

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
-  マイページ上で、自分がいいねした記事を一目で確認できるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- ローカル / 本番環境：マイページ上で、自分がいいねした記事を一目で確認できることを確認
- 新しくいいねした記事が一番上にきていることを確認

## その他
- 特になし