### PR TITLE
fix #80 下書き保存時に、titleとbodyのnullを許容

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   skip_before_action :require_login, only: [:index, :show]
-  before_action :set_article, only: [:edit, :destroy]
+  before_action :set_article, only: [:edit, :update, :destroy]
 
   def index
     if params[:latest]
@@ -48,7 +48,6 @@ class ArticlesController < ApplicationController
   def edit; end
 
   def update
-    @article = current_user.articles.find(params[:id])
 
     if params[:published].present?
       @article.status = :published
@@ -59,7 +58,7 @@ class ArticlesController < ApplicationController
     if @article.update(article_params)
       redirect_to article_path(@article), notice: '下書きが投稿されました。'
     else
-      render article_path(@article), notice: '下書きを再度保存しました。'
+      flash[:notice] = 'タイトルと本文を入力しないと、投稿できません'
     end
   end
 

--- a/app/views/articles/_first_favorite.html.erb
+++ b/app/views/articles/_first_favorite.html.erb
@@ -1,5 +1,5 @@
 <!-------------１つ目のいいねボタン------------->
-<%= link_to article_favorites_path(@article.id, type: :like_first), data: { turbo_method: :post }, class: "like-button-1" do %>
+<%= link_to article_favorites_path(article.id, type: :like_first), data: { turbo_method: :post }, class: "like-button-1" do %>
   <i class="bi bi-arrow-through-heart"></i>
   <%= @article.favorites.where(favorite_type: 'like_first').count %>
 <% end %>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -11,9 +11,10 @@
           <%= form.submit "投稿する", name: 'published', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
 
           <% if @article.draft? %>
-          <%= form_with model: @article do |form| %>
+          <%= form_with model: @article, url: article_path(@article) do |form| %>
           <%= form.submit "下書きする", name: 'draft', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
           <% end %>
+
         <% end %>
         <% end %>
       </div>

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,29 +1,20 @@
-<% if @article.favorited?(current_user, :like_first) %>
 <%= turbo_stream.replace "first-favorite-#{@article.id}", class: "like-button-1" , type: :like_first do %>
   <%= render 'articles/first_unfavorite', article: @article %>
 <% end %>
-<% end %>
 
-<% if @article.favorited?(current_user, :like_second) %>
 <%= turbo_stream.replace "second-favorite-#{@article.id}", class: "like-button-2", type: :like_first do %>
   <%= render 'articles/second_unfavorite', article: @article %>
 <% end %>
-<% end %>
 
-<% if @article.favorited?(current_user, :like_third) %>
 <%= turbo_stream.replace "third-favorite-#{@article.id}", class: "like-button-3",  type: :like_third do %>
   <%= render 'articles/third_unfavorite', article: @article %>
 <% end %>
-<% end %>
 
-<% if @article.favorited?(current_user, :like_forth) %>
 <%= turbo_stream.replace "forth-favorite-#{@article.id}", class: "like-button-4", type: :like_forth do %>
   <%= render 'articles/forth_unfavorite', article: @article %>
 <% end %>
-<% end %>
 
-<% if @article.favorited?(current_user, :like_fifth) %>
+
 <%= turbo_stream.replace "fifth-favorite-#{@article.id}", class: "like-button-5", type: :like_fifth do %>
   <%= render 'articles/fifth_unfavorite', article: @article %>
-<% end %>
 <% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,29 +1,19 @@
-<% if @article.favorited?(current_user, :like_first) %>
 <%= turbo_stream.replace "first-unfavorite-#{@article.id}", class: "unlike-button-1", type: :like_first do %>
   <%= render 'articles/first_favorite', article: @article %>
 <% end %>
-<% end %>
 
-<% if @article.favorited?(current_user, :like_second) %>
 <%= turbo_stream.replace "second-unfavorite-#{@article.id}", class: "unlike-button-2", type: :like_second do %>
   <%= render 'articles/second_favorite', article: @article %>
 <% end %>
-<% end %>
 
-<% if @article.favorited?(current_user, :like_third) %>
 <%= turbo_stream.replace "third-unfavorite-#{@article.id}", class: "unlike-button-3", type: :like_third do %>
   <%= render 'articles/third_favorite', article: @article %>
 <% end %>
-<% end %>
 
-<% if @article.favorited?(current_user, :like_forth) %>
 <%= turbo_stream.replace "forth-unfavorite-#{@article.id}", class: "unlike-button-4", type: :like_forth do %>
   <%= render 'articles/forth_favorite', article: @article %>
 <% end %>
-<% end %>
 
-<% if @article.favorited?(current_user, :like_fifth) %>
 <%= turbo_stream.replace "fifth-unfavorite-#{@article.id}", class: "unlike-button-5", type: :like_fifth do %>
   <%= render 'articles/fifth_favorite', article: @article %>
-<% end %>
 <% end %>


### PR DESCRIPTION
## チケットへのリンク
close #80 

## やったこと
- 下書き保存時に、tiltleとbodyが入力されていなくても、保存できるようにバリデーションにoptionをつけた
- 下書き保存時にtitleとbodyが未入力、投稿時も未入力の場合は投稿できないよう実装した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 下書き保存時にも、titleとbodyを全部入力する必要がなくなった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル：``` No template found for ArticlesController#update, rendering head :no_content```のエラー文
- 本番：[![Image from Gyazo](https://i.gyazo.com/57ace8e82bc9c02a4eeaf788a66549f9.png)](https://gyazo.com/57ace8e82bc9c02a4eeaf788a66549f9)が出てしまうので対処する]
-> 修正したコードが反映していなかった。本番環境でも``` No template found for ArticlesController#update, rendering head :no_content```のエラー文確認。フラッシュメッセージ対応は、別チケットで行う

## その他
- 特になし