### PR TITLE
fix #60_コメント投稿の非同期処理

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,6 @@ class CommentsController < ApplicationController
   def create
     @comment = current_user.comments.build(create_comment_params)
     @comment.save
-    redirect_to article_path(@comment.article_id)
   end
 
   def show
@@ -24,7 +23,6 @@ class CommentsController < ApplicationController
 
   def destroy
     @comment.destroy!
-    redirect_to article_path(@comment.article_id)
   end
   
 

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,29 +1,13 @@
 class FavoritesController < ApplicationController
   def create
     @article = Article.find(params[:article_id])
-
-    if params[:type] == 'like_first'
-      @favorite = current_user.favorites.new(article_id: params[:article_id], favorite_type: :like_first)
-    elsif params[:type] == 'like_second'
-      @favorite = current_user.favorites.new(article_id: params[:article_id], favorite_type: :like_second)
-    end
-
-    if @favorite.save
-      render :create
-    end
+    @favorite = current_user.favorites.new(article_id: params[:article_id], favorite_type: params[:type])
+    @favorite.save
   end
 
   def destroy
     @article = Article.find(params[:article_id])
-
-    if params[:type] == 'like_first'
-      @favorite = current_user.favorites.find_by(article_id: params[:article_id], favorite_type: :like_first)
-    elsif params[:type] == 'like_second'
-      @favorite = current_user.favorites.find_by(article_id: params[:article_id], favorite_type: :like_second)
-    end
-
-    if @favorite&.destroy!
-      render :destroy
-    end
+    @favorite = current_user.favorites.find_by(article_id: params[:article_id], favorite_type: params[:type])
+    @favorite.destroy!
   end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,4 +1,5 @@
 class Favorite < ApplicationRecord
   belongs_to :user
   belongs_to :article
+
 end

--- a/app/views/articles/_favorite.html.erb
+++ b/app/views/articles/_favorite.html.erb
@@ -1,20 +1,7 @@
 <!-------------１つ目のいいねボタン------------->
-<% if logged_in? %>
-  <% if @article.favorited?(current_user, :like_first) %>
-    <%= render 'articles/first_unfavorite', article: @article %>
-  <% else %>
-    <%= render 'articles/first_favorite', article: @article %>
-  <% end %>
-  <% end %>
-</div>
+<% if @article.favorited?(current_user, :like_first) %>
+  <%= render 'articles/first_unfavorite', article: @article %>
+<% else %>
+  <%= render 'articles/first_favorite', article: @article %>
+<% end %>
 <!-------------１つ目のいいねボタン------------->
-<!-------------2つ目のいいねボタン------------->
-<% if logged_in? %>
-  <% if @article.favorited?(current_user, :like_second) %>
-    <%= render 'articles/second_unfavorite', article: @article %>
-  <% else %>
-    <%= render 'articles/second_favorite', article: @article %>
-  <% end %>
-  <% end %>
-</div>
-<!-------------2つ目のいいねボタン------------->

--- a/app/views/articles/_first_favorite.html.erb
+++ b/app/views/articles/_first_favorite.html.erb
@@ -1,6 +1,4 @@
-<!-------------１つ目のいいねボタン------------->
-<%= link_to article_favorites_path(@article.id, type: :like_first), data: { turbo_method: :post, turbo_stream: true }, id: "first-favorite-#{@article.id}",class: "like-button-1" do %>
+<%= link_to article_favorites_path(@article.id, type: :like_first), data: { turbo_method: :post, turbo_stream: true },  id: ".first-favorite-#{@article.id}",class: "like-button-1" do %>
   <i class="bi bi-arrow-through-heart"></i>
   <%= @article.favorites.where(favorite_type: 'like_first').count %>
 <% end %>
-<!-------------１つ目のいいねボタン------------->

--- a/app/views/articles/_first_unfavorite.html.erb
+++ b/app/views/articles/_first_unfavorite.html.erb
@@ -1,8 +1,5 @@
-<!-------------１つ目のいいねボタン------------->
 <div class="tooltip" data-tip="参考になった！">
-  <%= link_to article_favorite_path(article, @article.id, type: :like_first), data: { turbo_method: :delete }, id: "first-unfavorite-#{@article.id}", class: "unlike-button-1" do %>
+  <%= link_to article_favorite_path(article, @article.id, type: :like_first), data: { turbo_method: :delete }, id: ".first-unfavorite-#{@article.id}", class: "unlike-button-1" do %>
     <i class="bi bi-arrow-through-heart-fill"></i>
     <%= @article.favorites.where(favorite_type: 'like_first').count %>
   <% end %>
-</div>
-<!-------------１つ目のいいねボタン------------->

--- a/app/views/articles/_second_favorite.html.erb
+++ b/app/views/articles/_second_favorite.html.erb
@@ -1,6 +1,6 @@
 <!-------------２つ目のいいねボタン------------->
 <div class="tooltip" data-tip="学びが深まった">
-  <%= link_to article_favorites_path(@article.id, type: :like_second), data: { turbo_method: :post, turbo_stream: true }, id: "second-favorite-#{@article.id}",class: "like-button-2" do %>
+  <%= link_to article_favorites_path(@article.id, type: :like_second), data: { turbo_method: :post, turbo_stream: true }, targets: "second-favorite-#{@article.id}", class: "like-button-2" do %>
     <i class="bi bi-award"></i>
     <%= @article.favorites.where(favorite_type: 'like_second').count %>
   <% end %>

--- a/app/views/articles/_second_unfavorite.html.erb
+++ b/app/views/articles/_second_unfavorite.html.erb
@@ -1,6 +1,6 @@
 <!-------------２つ目のいいねボタン------------->
 <div class="tooltip" data-tip="学びが深まった">
-  <%= link_to article_favorite_path(article, @article.id, type: :like_second), data: { turbo_method: :delete }, id: "second-unfavorite-#{@article.id}", class: "unlike-button-2" do %>
+  <%= link_to article_favorite_path(article, @article.id, type: :like_second), data: { turbo_method: :delete }, taegets: "second-unfavorite-#{@article.id}", class: "unlike-button-2" do %>
     <i class="bi bi-award-fill"></i>
     <%= @article.favorites.where(favorite_type: 'like_second').count %>
   <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -18,7 +18,11 @@
       <%= render 'articles/favorite', article: @article, favorite: @favorite %>
       <%= render 'shared/twitter' %>
       <%= render 'comments/form', comment: @comment, article: @article %>
-      <%= render @article.comments, comment: @comment %>
+        <table class="table">
+          <tbody id="table-comment">
+            <%= render @article.comments %>
+          </tbody>
+        </table>
     </div>
   </div>
 <% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,3 +1,4 @@
+<tr id="comment-<%= comment.id %>">
 <%= comment.user.name %>
 <%= comment.body %>
 
@@ -6,7 +7,6 @@
 <%=link_to '削除', comment_path(comment), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' }, class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
 <% end %>
 
-
 <%= render 'commentfavorites/commentfavorite', comment: @comment %>
 <%= render 'commentfavorites/uncommentfavorite', comment: @comment %>
-
+</tr>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,5 +1,7 @@
+<div class="row mb-3" id="comment-form">
 <%= form_with model: comment, url: article_comments_path(article) do |form| %>
   <%= form.label :body, "コメント"%>
   <%= form.text_area :body, placeholder: 'コメント', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
   <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
 <% end %>
+</div>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.prepend "table-comment" do %>
+    <%= render 'comments/comment', comment: @comment %>
+<% end %>
+
+<%= turbo_stream.replace "comment-form" do %>
+    <%= render 'comments/form', comment: Comment.new, article: @comment.article %>
+<% end %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.remove "comment-#{@comment.id}" do %>
+<% end %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,5 +1,7 @@
+<div class="table-comment">
 <%= form_with model: @comment, url: comment_path(@comment) do |form| %>
   <%= form.label :body, "コメント"%>
   <%= form.text_area :body, placeholder: 'コメント', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
   <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
 <% end %>
+</div>

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,7 +1,3 @@
-<%= turbo_stream.replace "first-favorite-#{@article.id}", class: "like-button-1" do %>
+<%= turbo_stream.replace ".first-favorite-#{@article.id}", class: "like-button-1" do %>
   <%= render 'articles/first_unfavorite', article: @article %>
-<% end %>
-
-<%= turbo_stream.replace "second-favorite-#{@article.id}", class: "like-button-2" do %>
-  <%= render 'articles/second_unfavorite', article: @article %>
 <% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,7 +1,3 @@
-<%= turbo_stream.replace "first-unfavorite-#{@article.id}", class: "like-unbutton-1" do %>
+<%= turbo_stream.replace ".first-unfavorite-#{@article.id}", class: "like-unbutton-1" do %>
   <%= render 'articles/first_favorite', article: @article %>
-<% end %>
-
-<%= turbo_stream.replace "second-unfavorite-#{@article.id}", class: "like-unbutton-2" do %>
-  <%= render 'articles/second_favorite', article: @article %>
 <% end %>


### PR DESCRIPTION
## チケットへのリンク
close #60 

## やったこと
- コメント投稿を同期処理から非同期処理に変更した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- コメント投稿を非同期処理に変更することで、ユーザビリティが向上した

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：コメントが非同期で投稿できることを確認

## その他
- 空のコメント投稿した際は、フラッシュメッセージで警告する
-> 別issueで対応