### PR TITLE
fix #92 コメント削除の非同期処理

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,12 +1,22 @@
 <tr id="comment-<%= comment.id %>">
-<%= comment.user.name %>
-<%= comment.body %>
-
-<% if comment.user == current_user %>
-<%=link_to '編集', edit_comment_path(comment), class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
-<%=link_to '削除', comment_path(comment), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' }, class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
-<% end %>
-
-<%= render 'commentfavorites/commentfavorite', comment: @comment %>
-<%= render 'commentfavorites/uncommentfavorite', comment: @comment %>
+  <td>
+    <h3 class="small"><%= comment.user.name %></h3>
+    <p><%= simple_format(comment.body) %></p>
+  </td>
+    <td class="action">
+      <ul class="list-inline justify-content-center" style="float: right;">
+        <li class="list-inline-item">
+        <% if comment.user == current_user %>
+          <%= link_to edit_comment_path(comment), class: "edit-comment-link" do %>
+            <i class="bi bi-pencil-fill"></i>
+            <% end %>
+        </li>
+        <li class="list-inline-item">
+          <%= link_to comment_path(comment), class: "delete-comment-link", data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+            <i class="bi bi-trash-fill"></i>
+          <% end %>
+          <% end %>
+        </li>
+      </ul>
+    </td>
 </tr>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,7 +1,5 @@
-<div class="table-comment">
 <%= form_with model: @comment, url: comment_path(@comment) do |form| %>
   <%= form.label :body, "コメント"%>
   <%= form.text_area :body, placeholder: 'コメント', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
   <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
 <% end %>
-</div>


### PR DESCRIPTION
## チケットへのリンク
close #92 

## やったこと
- コメントを非同期で削除できるよう実装した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- コメントが非同期で削除できるようになり、ユーザビリティが向上した

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：非同期でコメント削除できたことを確認

## その他
- 特になし