### PR TITLE
update #30 本番環境でのフラッシ ュメッセージの設定

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -35,7 +35,8 @@ class ArticlesController < ApplicationController
         redirect_to article_path(@article), notice: '投稿しました。'
       end
     else
-      render :new
+      flash[:error] = 'タイトルと本文を入力しないと、投稿できません'
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -58,7 +59,8 @@ class ArticlesController < ApplicationController
     if @article.update(article_params)
       redirect_to article_path(@article), notice: '投稿しました。'
     else
-      flash[:notice] = 'タイトルと本文を入力しないと、投稿できません'
+      flash[:error] = 'タイトルと本文を入力しないと、投稿できません'
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,9 +17,7 @@ class CommentsController < ApplicationController
   def edit; end
 
   def update
-    if @comment.update(update_comment_params)
-      redirect_to article_url, notice: 'コメントを編集しました。'
-    end
+    @comment.update(update_comment_params)
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,8 +13,8 @@ class UsersController < ApplicationController
       # sorceryのオートログイン機能
       auto_login(@user)
     else
-      flash[:alert] = '新規登録に失敗しました。'
-      render :new
+      flash.now[:alert] = '新規登録に失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/usersessions_controller.rb
+++ b/app/controllers/usersessions_controller.rb
@@ -11,7 +11,8 @@ class UsersessionsController < ApplicationController
     if @user
       redirect_to articles_path, notice: 'ログインしました。'
     else
-      render :new, error: 'ログインに失敗しました。'
+      flash.now[:alert] = 'ログインに失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -5,10 +5,12 @@
       <div class="w-full h-full flex flex-col">
         <%= form_with model: @article do |form| %>
           <%= form.label :title, "タイトル", class: "bg-white text-gray-600" %>
+          <%= render 'shared/error_messages', object: form.object%>
           <%= form.text_field :title, placeholder: 'タイトル', class: 'bg-white text-gray-600 textarea textarea-bordered mb-4 w-full'%>
           <br>
           <%= form.label :body, "本文", class: "bg-white text-gray-600"%>
-          <%= form.text_area :body, placeholder: '本文', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
+         <%= form.text_area :body, id: "markdown", placeholder: '本文', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
+          <div id="html"></div>
           <%= form.submit "投稿する", name: 'published', class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
 
           <% if @article.draft? %>
@@ -21,3 +23,14 @@
     </div>
   </div>
 </div>
+<script>
+  // idが「markdown」の要素を取得。ユーザーが入力を行ったときに以下の関数が実行される。
+  document.getElementById('markdown').addEventListener('input', function () {
+      // ユーザーが入力したMarkdownの内容を取得。
+      const markdown = document.getElementById('markdown').value;
+      // 取得したMarkdownをHTMLに変換。
+      const html = marked.parse(markdown);
+      // idが「html」の要素に変換したHTMLを表示。
+      document.getElementById('html').innerHTML = html;
+  });
+</script>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -22,7 +22,7 @@
       <%= render 'shared/twitter' %>
       <%= render 'comments/form', comment: @comment, article: @article %>
         <table class="table">
-          <tbody id="table-comment">
+          <tbody id="comments">
             <%= render @article.comments %>
           </tbody>
         </table>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -7,7 +7,7 @@
       <ul class="list-inline justify-content-center" style="float: right;">
         <li class="list-inline-item">
         <% if comment.user == current_user %>
-          <%= link_to edit_comment_path(comment), class: "edit-comment-link" do %>
+           <%= link_to edit_comment_path(comment), class: "edit-comment-link", data: { turbo_stream: true } do %>
             <i class="bi bi-pencil-fill"></i>
             <% end %>
         </li>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,5 +1,6 @@
-<div class="row mb-3" id="comment-form">
+<div id="new_comment">
 <%= form_with model: comment, url: article_comments_path(article) do |form| %>
+<%= render 'shared/error_messages', object: form.object%>
   <%= form.label :body, "コメント"%>
   <%= form.text_area :body, placeholder: 'コメント', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
   <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,7 +1,12 @@
-<%= turbo_stream.prepend "table-comment" do %>
+<% if @comment.errors.present? %>
+  <%= turbo_stream.replace "new_comment" do %>
+    <%= render 'comments/form', comment: @comment, article: @comment.article %>
+  <% end %>
+<% else %>
+<%= turbo_stream.prepend "comments" do %>
     <%= render 'comments/comment', comment: @comment %>
 <% end %>
-
-<%= turbo_stream.replace "comment-form" do %>
+<%= turbo_stream.replace "new_comment" do %>
     <%= render 'comments/form', comment: Comment.new, article: @comment.article %>
+<% end %>
 <% end %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,5 +1,0 @@
-<%= form_with model: @comment, url: comment_path(@comment) do |form| %>
-  <%= form.label :body, "コメント"%>
-  <%= form.text_area :body, placeholder: 'コメント', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
-  <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
-<% end %>

--- a/app/views/comments/edit.turbo_stream.erb
+++ b/app/views/comments/edit.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= form_with model: @comment, url: comment_path(@comment) do |form| %>
+app/views/comments/edit.turbo_stream.erb

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.prepend "comments" do %>
+  <%= render @comments %>
+<% end %>
+<%= turbo_stream.replace "new_comment" do %>
+  <%= render partial:"form", locals: {plan: @plan, comment: @comment} %>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,13 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        name: "名前"
+        password: "パスワード"
+        password_confirmation: "パスワード確認"
+        email: "メールアドレス"
+      article:
+        body: "本文"
+        title: "タイトル"
+      comment:
+        body: "本文"


### PR DESCRIPTION
## チケットへのリンク
close #30 

## やったこと
- 各種フラッシュメッセージ、バリデーションエラー内容のエラーが表示するよう設定をした

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- アクションに対し、ブラウザからの反応があることでインタラクティブにアプリを使用している感覚が生まれる
- 何が原因でエラーが出されているのか、見てわかるようになった（バリデーションエラー）

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル ：issue項目に挙げているフラッシュメッセージは出ることを確認した
-  本番環境: 下記確認済み
- [x] ログイン時
- [x] ログアウト時
- [x] ログイン失敗時
- [x] ユーザー新規登録成功時
- [x] ユーザー新規登録失敗時
- [x] ユーザー登録失敗時のバリデーションエラー
- [x] 新規投稿時
- [x] 投稿時のバリデーションエラー
-> ```status: :unprocessable_entity```がないと、バリデーションエラーも出ない
- [x] 新規で下書き時
- [x] 下書き-> 投稿時
- [x] 投稿済-> 編集して投稿時
- [x] 記事削除時  
- [x] 空のコメント時にエラー出す
- [x] バリデーション内容の日本語対応

## その他
- 特になし