### PR TITLE
fix #97 パスワードリセット画面の変更、メール受信状況の確認

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
       # sorceryのオートログイン機能
       auto_login(@user)
     else
-      flash.now[:alert] = '新規登録に失敗しました'
+      flash[:alert] = '新規登録に失敗しました'
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,5 +1,7 @@
 <% content_for :title, page_title("パスワード再設定") %>
-<h1>Choose a new password</h1>
+<div class="bg-white flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
+<div class= "w-5/6 mx-auto max-w-screen-xl justify-center">
+<h1>パスワードを再設定する</h1>
 <%= form_for @user, :url => password_reset_path(@token), :html => {:method => :put} do |f| %>
   <% if @user.errors.any? %>
     <div id="error_explanation">
@@ -13,19 +15,19 @@
     </div>
   <% end %>
     
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= @user.email %>
+  <div class="field ">
+    <%= f.label :email, "メールアドレス", class: 'mt-3block text-sm font-medium leading-6 text-gray-900' %><br />
+    <%= @user.email%>
   </div>
   <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password %>
+    <%= f.label :password, "パスワード(8文字以上/半角の英数字のみ)", class: 'mt-3block text-sm font-medium leading-6 text-gray-900' %><br />
+    <%= f.password_field :password, required: true, class: "mb-3 bg-white block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
   </div>
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation %>
+  <div class="field ">
+    <%= f.label :password_confirmation, "パスワード確認", class: 'mt-3block text-sm font-medium leading-6 text-gray-900' %><br />
+    <%= f.password_field :password_confirmation, required: true, class: "mb-3 bg-white block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
   </div>
-  <div class="actions">
-    <%= f.submit %>
+  <div class="actions ">
+    <%= f.submit "登録", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
   </div>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,7 +7,6 @@
     <div class="bg-white px-6 py-12 sm:rounded-lg sm:px-12">
       <%= form_with model: @user do |form| %>
       <%= render 'shared/error_messages', object: form.object%>
-       <%= render 'layouts/flash_messages' %>
       <div>
         <%= form.label :name, '名前', class: 'text-sm font-medium leading-6 text-gray-900' %>
         <div class="mb-2">

--- a/app/views/usersessions/_forgot_password_form.html.erb
+++ b/app/views/usersessions/_forgot_password_form.html.erb
@@ -1,7 +1,8 @@
 <%= form_with url: password_resets_path, local: true, method: :post do |form| %>
   <div class="field">
-    <%= form.label :email %><br />
-    <%= form.text_field :email %>
-    <%= form.submit "Reset my password!" %>
+    <%= form.label :email, 'メールアドレス', class: 'block text-sm font-medium leading-6 text-gray-900' %><br />
+    <%= form.text_field :email, class: "bg-white rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300" %>
+    <%= form.submit "パスワードを再設定する" %>
   </div>
 <% end %>
+

--- a/app/views/usersessions/new.html.erb
+++ b/app/views/usersessions/new.html.erb
@@ -25,7 +25,7 @@
           <button type="submit" class="mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">ログイン</button>
         </div>
       </form>
-<h1>Forgot Password?</h1>
+<h1>パスワードをお忘れの方はこちら</h1>
 <%= render 'forgot_password_form' %>
     </div>
           


### PR DESCRIPTION
## チケットへのリンク
close #97 

## やったこと
- パスワードリセット画面関連のview変更
- パスワードリセットメールが受信できるかの確認

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- メールがちゃんと受信できるかを確認した

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：viewが変更されていること、本番環境でもメールが受信できることを確認した

## その他
- 特になし