### PR TITLE
fix #54 マークダウン記法の対応確認

### DIFF
--- a/app/assets/stylesheets/kramdown_custom.css
+++ b/app/assets/stylesheets/kramdown_custom.css
@@ -1,3 +1,4 @@
+/* 見出し */
 h1 {
     font-size: 1.65em; 
     margin-top: 1em;
@@ -33,21 +34,28 @@ h6 {
     margin-top: 0.5em;
     margin-bottom: 0.5em;
 }
+/* 見出し */
 
+
+/* コードブロック */
+/* pre: 複数行のコードブロック */
 pre {
     background-color: #f5f5f5;  /* 背景色 */
     padding: 10px;              /* 内側の余白 */
     border-radius: 5px;         /* 角の丸み */
     border: 1px solid #ddd;     /* 枠線 */
-    overflow: auto;             /* オーバーフロー時にスクロール */
+    overflow: auto;             /* 要素の中身がその要素のサイズを超えてしまった場合に、スクロールバーを表示して中身を見れるようにする設定 */
 }
 
+/* code: インラインコード */
 code {
     background-color: #f5f5f5;
     padding: 2px 4px;
     border-radius: 4px;
 }
+/* コードブロック */
 
+/* 引用 */
 blockquote {
     background-color: #f9f9f9; /* 背景色 */
     border-left: 5px solid #ccc; /* 左側のボーダー */
@@ -59,49 +67,57 @@ blockquote {
 blockquote p {
     display: inline; /* ブロック内の段落をインライン表示 */
 }
+/* 引用 */
 
+
+/* 水平線 */
 body hr {
-    border: 0;
-    border-top: 1px solid #ccc;
-    margin: 1em 0;
+    border: 0;  /* 枠線のスタイル */
+    border-top: 1px solid #ccc;  /* 上部の枠線 */
+    margin: 1em 0;  /* 外側の余白 */
 }
 
 /* 番号付きリストのスタイル */
 ol {
-    list-style-type: decimal;
-    margin: 0;
-    padding: 0 0 0 2em;
+    list-style-type: decimal;  /* リストアイテムのスタイルを設定 */
+    margin: 0;  /* 外側の余白 */
+    padding: 0 0 0 2em;  /* 内側の余白 */
 }
 
+/*  順序付きリスト（<ol>）内のリストアイテム（<li>）に対してCSSスタイルを適用するためのセレクター */
 ol li {
-    margin: 0.5em 0;
+    margin: 0.5em 0;  /* 外側の余白 */
 }
-
-link {
-    border-bottom: currentColor 1px solid
-}
+/* 番号付きリストのスタイル */
 
 /* テーブルのスタイル */
 table {
-    border-collapse: collapse;
-    width: 100%;
-    margin: 1em 0;
-    border: 1px solid #ddd;
+    border-collapse: collapse;  /* ボーダーを崩さずに結合 */
+    width: 100%;  /* 幅を設定 */
+    margin: 1em 0;  /* 外側の余白 */
+    border: 1px solid #ddd;  /* 枠線の設定 */
 }
 
+/* テーブルセルのスタイル */
 table th, table td {
-    border: 1px solid #ddd;
-    padding: 8px;
-    text-align: left;
+    border: 1px solid #ddd;  /* 枠線 */
+    padding: 8px; /* 内側 */
+    text-align: left; /*  テキストの位置を設定 */
 }
 
+/* テーブルヘッダーのスタイル */
 table th {
-    background-color: #f2f2f2;
+    background-color: #f2f2f2;  /*  背景色を設定 */
 }
 
-hr {
-    height: 2px;
-    background-color: rgb(100, 98, 98);
-    width: 100%;
-    border: none;
-   }
+/* すべてのリンクに下線を引く */
+a {
+    text-decoration: underline;
+    color: inherit;
+}
+
+/* app-link クラスを持つリンクには下線を引かない */
+a.app-link {
+    text-decoration: none;
+    color: inherit;
+}

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -43,7 +43,7 @@ class PasswordResetsController < ApplicationController
     @user.password_confirmation = params[:user][:password_confirmation]
     # the next line clears the temporary token and updates the password
     if @user.change_password(params[:user][:password])
-      redirect_to(root_path, :notice => 'Password was successfully updated.')
+      redirect_to(root_path, :notice => 'パスワードの再設定が完了しました')
     else
       render :action => "edit"
     end

--- a/app/views/articles/_fifth_favorite.html.erb
+++ b/app/views/articles/_fifth_favorite.html.erb
@@ -1,5 +1,5 @@
 <div class="tooltip" data-tip="詳細をもっと知りたい">
-<%= link_to article_favorites_path(@article.id, type: :like_fifth), data: { turbo_method: :post, turbo_stream: true },  id: "fifth-favorite",class: "like-button-5" do %>
+<%= link_to article_favorites_path(@article.id, type: :like_fifth), data: { turbo_method: :post, turbo_stream: true },  id: "fifth-favorite",class: "app-link like-button-5" do %>
   <i class="bi bi-bell"></i>
   <%= @article.favorites.where(favorite_type: 'like_fifth').count %>
 <% end %>

--- a/app/views/articles/_fifth_unfavorite.html.erb
+++ b/app/views/articles/_fifth_unfavorite.html.erb
@@ -1,4 +1,4 @@
-<%= link_to article_favorite_path(article, @article.id, type: :like_fifth), data: { turbo_method: :delete }, id: "fifth-unfavorite", class: "unlike-button-5" do %>
+<%= link_to article_favorite_path(article, @article.id, type: :like_fifth), data: { turbo_method: :delete }, id: "fifth-unfavorite", class: "app-link unlike-button-5" do %>
   <i class="bi bi-bell-fill"></i>
   <%= @article.favorites.where(favorite_type: 'like_fifth').count %>
 <% end %>

--- a/app/views/articles/_first_favorite.html.erb
+++ b/app/views/articles/_first_favorite.html.erb
@@ -1,5 +1,5 @@
 <div class="tooltip" data-tip="参考になった！">
-<%= link_to article_favorites_path(@article.id, type: :like_first), data: { turbo_method: :post, turbo_stream: true },  id: "first-favorite", class: "like-button-1" do %>
+<%= link_to article_favorites_path(@article.id, type: :like_first), data: { turbo_method: :post, turbo_stream: true },  id: "first-favorite", class: "app-link like-button-1" do %>
   <i class="bi bi-arrow-through-heart"></i>
   <%= @article.favorites.where(favorite_type: 'like_first').count %>
 <% end %>

--- a/app/views/articles/_first_unfavorite.html.erb
+++ b/app/views/articles/_first_unfavorite.html.erb
@@ -1,4 +1,4 @@
-<%= link_to article_favorite_path(article, @article.id, type: :like_first), data: { turbo_method: :delete }, id: "first-unfavorite", class: "unlike-button-1" do %>
+<%= link_to article_favorite_path(article, @article.id, type: :like_first), data: { turbo_method: :delete }, id: "first-unfavorite", class: "app-link unlike-button-1" do %>
   <i class="bi bi-arrow-through-heart-fill"></i>
   <%= @article.favorites.where(favorite_type: 'like_first').count %>
 <% end %>

--- a/app/views/articles/_forth_favorite.html.erb
+++ b/app/views/articles/_forth_favorite.html.erb
@@ -1,5 +1,5 @@
 <div class="tooltip" data-tip="独自の視点！">
-  <%= link_to article_favorites_path(@article.id, type: :like_forth), data: { turbo_method: :post, turbo_stream: true },  id: "forth-favorite",class: "like-button-4" do %>
+  <%= link_to article_favorites_path(@article.id, type: :like_forth), data: { turbo_method: :post, turbo_stream: true },  id: "forth-favorite",class: "app-link like-button-4" do %>
     <i class="bi bi-brightness-alt-high"></i>
     <%= @article.favorites.where(favorite_type: 'like_forth').count %>
   <% end %>

--- a/app/views/articles/_forth_unfavorite.html.erb
+++ b/app/views/articles/_forth_unfavorite.html.erb
@@ -1,4 +1,4 @@
-<%= link_to article_favorite_path(article, @article.id, type: :like_forth), data: { turbo_method: :delete }, id: "forth-unfavorite", class: "unlike-button-4" do %>
+<%= link_to article_favorite_path(article, @article.id, type: :like_forth), data: { turbo_method: :delete }, id: "forth-unfavorite", class: "app-link unlike-button-4" do %>
   <i class="bi bi-brightness-alt-high-fill"></i>
   <%= @article.favorites.where(favorite_type: 'like_forth').count %>
 <% end %>

--- a/app/views/articles/_second_favorite.html.erb
+++ b/app/views/articles/_second_favorite.html.erb
@@ -1,5 +1,5 @@
 <div class="tooltip" data-tip="学びが深まった">
-<%= link_to article_favorites_path(@article.id, type: :like_second), data: { turbo_method: :post, turbo_stream: true },  id: "second-favorite", class: "like-button-2" do %>
+<%= link_to article_favorites_path(@article.id, type: :like_second), data: { turbo_method: :post, turbo_stream: true },  id: "second-favorite", class: "app-link like-button-2" do %>
   <i class="bi bi-award"></i>
   <%= @article.favorites.where(favorite_type: 'like_second').count %>
 <% end %>

--- a/app/views/articles/_second_unfavorite.html.erb
+++ b/app/views/articles/_second_unfavorite.html.erb
@@ -1,4 +1,4 @@
-<%= link_to article_favorite_path(article, @article.id, type: :like_second), data: { turbo_method: :delete }, id: "second-unfavorite", class: "unlike-button-2" do %>
+<%= link_to article_favorite_path(article, @article.id, type: :like_second), data: { turbo_method: :delete }, id: "second-unfavorite", class: "app-link unlike-button-2" do %>
   <i class="bi bi-award-fill"></i>
   <%= @article.favorites.where(favorite_type: 'like_second').count %>
 <% end %>

--- a/app/views/articles/_third_favorite.html.erb
+++ b/app/views/articles/_third_favorite.html.erb
@@ -1,5 +1,5 @@
 <div class="tooltip" data-tip="解説が丁寧">
-<%= link_to article_favorites_path(@article.id, type: :like_third), data: { turbo_method: :post, turbo_stream: true },  id: "third-favorite", class: "like-button-3" do %>
+<%= link_to article_favorites_path(@article.id, type: :like_third), data: { turbo_method: :post, turbo_stream: true },  id: "third-favorite", class: "app-link like-button-3" do %>
   <i class="bi bi-arrow-through-heart"></i>
   <%= @article.favorites.where(favorite_type: 'like_third').count %>
 <% end %>

--- a/app/views/articles/_third_unfavorite.html.erb
+++ b/app/views/articles/_third_unfavorite.html.erb
@@ -1,4 +1,4 @@
-<%= link_to article_favorite_path(article, @article.id, type: :like_third), data: { turbo_method: :delete }, id: "third-unfavorite", class: "unlike-button-3" do %>
+<%= link_to article_favorite_path(article, @article.id, type: :like_third), data: { turbo_method: :delete }, id: "third-unfavorite", class: "app-link unlike-button-3" do %>
   <i class="bi bi-arrow-through-heart-fill"></i>
   <%= @article.favorites.where(favorite_type: 'like_third').count %>
 <% end %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -7,15 +7,15 @@
     <%= f.submit '検索', class: "text-gray-600 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
     <% end %>
 
-    <%= link_to '新しい順', articles_path(latest: "true") %>
-    <%= link_to '古い順', articles_path(old: "true") %>
+    <%= link_to '新しい順', articles_path(latest: "true"), class: "app-link " %>
+    <%= link_to '古い順', articles_path(old: "true"), class: "app-link " %>
 
   </div>
   <div class= "grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
     <% if @articles.present? %>
       <% @articles.each do |article| %>
       <div class="p-4 border rounded-lg">
-        <h2 class="text-xl mt-2 text-gray-600"><%= link_to article.title, article_path(article)%></h2> 
+        <h2 class="text-xl mt-2 text-gray-600"><%= link_to article.title, article_path(article), class: "app-link" %></h2> 
         <h3 class="text-sm text-gray-600">作成日：<%= l article.created_at, format: :long %></h3>
         <h3 class="text-sm text-gray-600">更新日：<%= l article.updated_at, format: :long %></h3>
         <h3 class="text-sm text-gray-600"><%= article.user.name %></h3>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -7,8 +7,8 @@
 
   <div class= "flex justify-center gap-7 mb-10 mt-10">
     <% if @article.user == current_user %>
-      <%=link_to '編集', edit_article_path(@article), class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
-      <%=link_to '削除', article_path(@article), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' }, class: "rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+      <%=link_to '編集', edit_article_path(@article), class: "app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+      <%=link_to '削除', article_path(@article), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' }, class: "app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
     <% end %>
   </div>
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -7,12 +7,12 @@
       <ul class="list-inline justify-content-center" style="float: right;">
         <li class="list-inline-item">
         <% if comment.user == current_user %>
-           <%= link_to edit_comment_path(comment), class: "edit-comment-link", data: { turbo_stream: true } do %>
+           <%= link_to edit_comment_path(comment), class: "app-link edit-comment-link", data: { turbo_stream: true } do %>
             <i class="bi bi-pencil-fill"></i>
             <% end %>
         </li>
         <li class="list-inline-item">
-          <%= link_to comment_path(comment), class: "delete-comment-link", data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+          <%= link_to comment_path(comment), class: "app-link delete-comment-link", data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
             <i class="bi bi-trash-fill"></i>
           <% end %>
           <% end %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="next btn btn-sm btn-ghost m-2">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: "app-link " %>
 </span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -9,10 +9,10 @@
 -%>
 <% if page.current? %>
   <span class="page current">
-    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "rounded-full btn btn-sm btn-neutral m-2"} %>
+    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "app-link rounded-full btn btn-sm btn-neutral m-2"} %>
   </span>
 <% else %>
   <span class="page">
-    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "rounded-full btn btn-sm btn-ghost m-2"} %>
+    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "app-link rounded-full btn btn-sm btn-ghost m-2"} %>
   </span>
 <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="prev btn btn-sm btn-ghost m-2">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: "app-link " %>
 </span>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,5 +4,5 @@
 <%= current_user.email %>
 <p>氏名</p>
 <%= current_user.name %>
-<%= link_to '編集', edit_profile_path %>
+<%= link_to '編集', edit_profile_path, class: "app-link " %>
 

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -2,12 +2,12 @@
   <nav class="mx-auto flex max-w-7xl items-center justify-between p-6 lg:px-8" aria-label="Global">
     <div class="flex lg:flex-1 items-center">
       <%= link_to root_path do %>
-        <%= image_tag "logo.jpeg", class: "card-img-top", width: "100", height:"100" %>
+        <%= image_tag "logo.jpeg", class: "card-img-top app-link", width: "100", height:"100" %>
       <% end %>
     </div>
     <div class="lg:flex lg:gap-x-12 font-biz items-center">
-      <%= link_to "記事を投稿", new_article_path, class: "text-sm font-semibold leading-6 text-slate-200" %>
-      <%= link_to "記事を閲覧", articles_path, class: "text-sm font-semibold leading-6 text-slate-200" %>
+      <%= link_to "記事を投稿", new_article_path, class: "app-link text-sm font-semibold leading-6 text-slate-200" %>
+      <%= link_to "記事を閲覧", articles_path, class: "app-link text-sm font-semibold leading-6 text-slate-200" %>
     </div>
     <div class="lg:flex lg:flex-1 lg:justify-end font-biz items-center">
     </div>
@@ -19,10 +19,10 @@
     </svg>
   </div>
   <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-    <li><a><%= link_to "マイページ", profile_path, class: "text-sm font-semibold leading-6 text-slate-200" %></a></li>
-    <li><a><%= link_to "自分の記事", my_articles_users_path, class: "text-sm font-semibold leading-6 text-slate-200" %></a></li>
-    <li><a><%= link_to "いいねした記事", my_favorites_users_path, class: "text-sm font-semibold leading-6 text-slate-200" %></a></li>
-    <li><a><%= link_to 'ログアウト', :logout, data: { turbo_method: :delete }, class: 'text-sm font-semibold leading-6 text-slate-200' %></a></li>
+    <li><a><%= link_to "マイページ", profile_path, class: " app-link text-sm font-semibold leading-6 text-slate-200" %></a></li>
+    <li><a><%= link_to "自分の記事", my_articles_users_path, class: "app-link text-sm font-semibold leading-6 text-slate-200" %></a></li>
+    <li><a><%= link_to "いいねした記事", my_favorites_users_path, class: "app-link text-sm font-semibold leading-6 text-slate-200" %></a></li>
+    <li><a><%= link_to 'ログアウト', :logout, data: { turbo_method: :delete }, class: 'app-link text-sm font-semibold leading-6 text-slate-200' %></a></li>
   </ul>
 </div>
 </nav>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -2,15 +2,15 @@
   <nav class="mx-auto flex max-w-7xl items-center justify-between p-6 lg:px-8" aria-label="Global">
     <div class="flex lg:flex-1">
       <%= link_to root_path do %>
-        <%= image_tag "logo.jpeg", class: "card-img-top", width: "100", height:"100" %>
+        <%= image_tag "logo.jpeg", class: "card-img-top app-link", width: "100", height:"100" %>
       <% end %>
     </div>
     <div class="lg:flex lg:gap-x-12 font-biz">
-      <%=link_to "記事を閲覧", articles_path, class: "text-sm font-semibold leading-6 text-slate-200" %>
-      <%= link_to '新規登録', new_user_path, class: "text-sm font-semibold leading-6 text-slate-200" %>
+      <%=link_to "記事を閲覧", articles_path, class: "app-link text-sm font-semibold leading-6 text-slate-200" %>
+      <%= link_to '新規登録', new_user_path, class: "app-link text-sm font-semibold leading-6 text-slate-200" %>
     </div>
     <div class="lg:flex lg:flex-1 lg:justify-end font-biz">
-      <%= link_to 'ログイン', :login, class: 'text-sm font-semibold leading-6 text-slate-200' %>
+      <%= link_to 'ログイン', :login, class: 'app-link text-sm font-semibold leading-6 text-slate-200' %>
     </div>
 </nav>
 </header>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -17,7 +17,7 @@
     <div class="mt-8 md:order-1 md:mt-0">
       <p class="text-center text-sm leading-5 text-gray-600">&copy; 2024 Miniita.</p>
     </div>
-     <a href="https://docs.google.com/forms/d/e/1FAIpQLSchOBDvWLYTdjRSw99-y7VQowyXGBG61JQaxaEU-W98V_Fr3g/viewform?usp=sf_link" class="text-gray-400 hover:text-gray-600">
+     <a href="https://docs.google.com/forms/d/e/1FAIpQLSchOBDvWLYTdjRSw99-y7VQowyXGBG61JQaxaEU-W98V_Fr3g/viewform?usp=sf_link" class="app-link text-gray-400 hover:text-gray-600">
     <div class="mt-8 md:order-1 md:mt-0">
       <p class="text-center text-sm leading-5 text-gray-600">お問い合わせフォーム</p>
     </div>

--- a/app/views/shared/_twitter.html.erb
+++ b/app/views/shared/_twitter.html.erb
@@ -1,6 +1,6 @@
 <!-----margin-top: 5pxは、いいねボタンと高さを合わせるために記載------->
 <%= link_to "https://twitter.com/intent/tweet?url=#{article_url(@article)}&text=%0a%0a#{@article.title} %23Miniita %23技術記事をもっと身近に%0a%0a", 
-:onclick=>"window.open(this.href,'hoge', 'height=480, width=640');return false;", target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェアする", style: "display: inline-block; margin-top: 5px;" do %>
+:onclick=>"window.open(this.href,'hoge', 'height=480, width=640');return false;", target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェアする", style: "display: inline-block; margin-top: 5px;", class: "app-link" do %>
   <svg class="style-1b1cd5z" viewBox="0 0 20 20" style="width: 20px; height: 20px;">
     <path d="m11.68 8.62 6.55-7.62h-1.55l-5.69 6.62-4.55-6.62h-5.25l6.88 10.01-6.88 7.99h1.55l6.01-6.99 4.8 6.99h5.24l-7.13-10.38zm-2.13 2.47-.7-1-5.54-7.92h2.39l4.47 6.4.7 1 5.82 8.32h-2.39l-4.75-6.79z"></path>
   </svg>

--- a/app/views/users/my_articles.html.erb
+++ b/app/views/users/my_articles.html.erb
@@ -4,7 +4,7 @@
   <% @draft_articles.each do |article| %>
   <div class="p-4 border rounded-lg mb-3">
     <li>
-      <%= link_to article.title, article %>
+      <%= link_to article.title, article, class: "app-link" %>
     </li>
     </div>
   <% end %>
@@ -17,7 +17,7 @@
   <% @published_articles.each do |article| %>
   <div class="p-4 border rounded-lg mb-3">
     <li>
-      <%= link_to article.title, article %>
+      <%= link_to article.title, article, class: "app-link" %>
     </li>
   </div>
   <% end %>

--- a/app/views/users/my_favorites.html.erb
+++ b/app/views/users/my_favorites.html.erb
@@ -4,7 +4,7 @@
   <% @favorites.each do |favorite| %>
   <div class="p-4 border rounded-lg mb-3">
     <li>
-      <%=link_to favorite.article.title, article_path(favorite.article) %>
+      <%=link_to favorite.article.title, article_path(favorite.article), class: "app-link"  %>
     </li>
     </div>
   <% end %>


### PR DESCRIPTION
## チケットへのリンク
close #54 

## やったこと
- マークダウン記法の対応確認を行った

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 箇条書きリストを除き、基本的にはマークダウン記法でのプレビュー、出力が問題ないことを確認

## できなくなること（ユーザ目線）
- 箇条書きリストのみ使用できない

## 動作確認
-  ローカル ：問題ないことを確認
- 本番環境：
    - [x] 見出し
    - [x] 太字
    - [x] イタリック（斜体）
    - [x] 太字かつイタリック
    - [x] 訂正線 gem 'kramdown-parser-gfm
    - [x] 下線
    - [x] 水平線
    - [x] URLリンク
    -> URLのリンクに飛ぶが、下線等わかるようにCSS設定する
   -> aタグで設定、アプリ内のaタグリンクは、classで"app-link"と指定し除外するようにした
    - [x] ファイル挿入 
    - [x] 動画（GIF）
    - [x] 画像  
    - [x] 引用
    - [x] 二重引用
    - [x] pre記法(スペース4 or タブ) 
    -> プレビューと出力が異なる箇所あり。冒頭の空白を消したら、プレビューと同一出力になったので解決済みとする。
    - [x] code（コードブロック/インラインコード）
    - [x] テキストカラー（文字の色）
    - [x] チェックリスト gem 'kramdown-parser-gfm　-> チェックは入るが、色がわかりづらい
    - [ ] 箇条書きリスト CSS追加より
    - [x] 番号付きリスト CSS追加より
    -> 半角スペースを3つ下げることで、番号が下がった箇所は1からスタートする
    - [x] 折りたたみ表示
    - [x] テーブル CSS追加より
    - [x] GFM:リンクテキスト簡易記法
    -> プレビューでは、単なるURLとして表記。一覧では、単なる文字として表示される。今回は不採用。
    - [x] GFM:pre記法(シンタックスハイライト)
    - [x] GFM:pre記法(チルダ×3)
    - [x] GFM:pre記法(バッククォート×3)
    - [x] GFM:ページ内リンク

## その他
- 特になし