### PR TITLE
fix #90 コメント編集機能の非同期処理

### DIFF
--- a/app/views/comments/edit.turbo_stream.erb
+++ b/app/views/comments/edit.turbo_stream.erb
@@ -1,2 +1,7 @@
-<%= form_with model: @comment, url: comment_path(@comment) do |form| %>
-app/views/comments/edit.turbo_stream.erb
+<%= turbo_stream.replace "new_comment" do %>
+  <%= form_with model: @comment do |form| %>
+    <%= form.label :body, "コメント"%>
+    <%= form.text_area :body, placeholder: 'コメント', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
+    <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+  <% end %>
+<% end %>

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -1,6 +1,22 @@
-<%= turbo_stream.prepend "comments" do %>
-  <%= render @comments %>
-<% end %>
-<%= turbo_stream.replace "new_comment" do %>
-  <%= render partial:"form", locals: {plan: @plan, comment: @comment} %>
+<%= turbo_stream.replace "comments" do %>
+  <td>
+    <h3 class="small"><%= @comment.user.name %></h3>
+    <p><%= simple_format(@comment.body) %></p>
+  </td>
+    <td class="action">
+      <ul class="list-inline justify-content-center" style="float: right;">
+        <li class="list-inline-item">
+        <% if @comment.user == current_user %>
+           <%= link_to edit_comment_path(@comment), class: "app-link edit-comment-link", data: { turbo_stream: true } do %>
+            <i class="bi bi-pencil-fill"></i>
+            <% end %>
+        </li>
+        <li class="list-inline-item">
+          <%= link_to comment_path(@comment), class: "app-link delete-comment-link", data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+            <i class="bi bi-trash-fill"></i>
+          <% end %>
+          <% end %>
+        </li>
+      </ul>
+    </td>
 <% end %>


### PR DESCRIPTION
## チケットへのリンク
close #90 

## やったこと
- コメント編集を非同期で実装

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- コメント編集画面を投稿欄と変えないことで、動作が少なくなった

## できなくなること（ユーザ目線）
- コメント編集後に空のコメント欄が出ない
- コメント編集投稿時に、コメント一覧が見えなくなる
->別チケットで対応する

## 動作確認
-  ローカル / 本番環境：非同期でコメント編集できることを確認した

## その他
- 特になし