### PR TITLE
fix #118_マイページのいいね表示方法の変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,9 +26,14 @@ class UsersController < ApplicationController
   end
 
   def my_favorites
-    @favorites = current_user.favorites.includes(:article).order(created_at: :desc)
-  end
+    @like_first = current_user.favorites.where(favorite_type: :like_first).includes(:user).order(created_at: :desc)
+    @like_second = current_user.favorites.where(favorite_type: :like_second).includes(:user).order(created_at: :desc)
+    @like_third = current_user.favorites.where(favorite_type: :like_third).includes(:user).order(created_at: :desc)
+    @like_forth = current_user.favorites.where(favorite_type: :like_forth).includes(:user).order(created_at: :desc)
+    @like_fifth = current_user.favorites.where(favorite_type: :like_fifth).includes(:user).order(created_at: :desc)
 
+  end
+  
   private
 
   def user_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :commentfavorites, dependent: :destroy
   has_many :authentications, dependent: :destroy
+  
   accepts_nested_attributes_for :authentications
   has_one :profile
 

--- a/app/views/users/my_favorites.html.erb
+++ b/app/views/users/my_favorites.html.erb
@@ -1,8 +1,53 @@
 <% content_for :title, page_title('いいねした投稿') %>
   <div class="w-5/6 mx-auto max-w-screen-xl">
     <h1>いいねした記事</h1>
+      <h3>参考になった！<h3>
       <ul>
-        <% @favorites.each do |favorite| %>
+        <% @like_first.each do |favorite| %>
+          <div class="p-4 border rounded-lg mb-3">
+            <li>
+              <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>
+            </li>
+          </div>
+        <% end %>
+      </ul>
+
+      <h3>学びが深まった<h3>
+      <ul>
+        <% @like_second.each do |favorite| %>
+          <div class="p-4 border rounded-lg mb-3">
+            <li>
+              <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>
+            </li>
+          </div>
+        <% end %>
+      </ul>
+
+      <h3>解説が丁寧<h3>
+      <ul>
+        <% @like_third.each do |favorite| %>
+          <div class="p-4 border rounded-lg mb-3">
+            <li>
+              <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>
+            </li>
+          </div>
+        <% end %>
+      </ul>
+
+      <h3>独自の視点！<h3>
+      <ul>
+        <% @like_forth.each do |favorite| %>
+          <div class="p-4 border rounded-lg mb-3">
+            <li>
+              <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>
+            </li>
+          </div>
+        <% end %>
+      </ul>
+
+      <h3>詳細をもっと知りたい<h3>
+      <ul>
+        <% @like_fifth.each do |favorite| %>
           <div class="p-4 border rounded-lg mb-3">
             <li>
               <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>


### PR DESCRIPTION
## チケットへのリンク
close #118 

## やったこと
- マイページのいいね欄を、各カラムごとに表示させるように変更した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 何のいいねを押した記事か、見たらわかるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：各カラムごとに表示されていることを確認した

## その他
- 特になし