### PR TITLE
fix #117 コメント編集機能の修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CommentsController < ApplicationController
   before_action :set_comment, only: %i[edit update destroy]
   def index

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -16,8 +16,9 @@ class OauthsController < ApplicationController
         reset_session
         auto_login(@user)
         redirect_to articles_path, success: "#{provider.titleize}アカウントでログインしました。"
-      rescue
-        redirect_to root_path, error: "#{provider.titleize}アカウントでのログインに失敗しました。"
+      rescue => e
+        puts e
+
       end
     end
   end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,28 +1,24 @@
 <% content_for :title, page_title('詳細') %>
-<div class="w-5/6 mx-auto max-w-screen-xl">
-  <h1 class="text-3xl mt-5 flex justify-center"><%= @article.title %></h1>
-  <h2 class="text-base mt-5 flex justify-center">作成日：<%= l @article.created_at, format: :long %></h2>
-  <h2 class="text-base flex justify-center">更新日：<%= l @article.updated_at, format: :long %></h2>
-  <h3 class="mt-10 bg-white"><%= render_markdown(@article.body).html_safe %></h3>
-
-  <div class="flex justify-center gap-7 mb-10 mt-10">
-    <% if @article.user == current_user %>
-      <%= link_to '編集', edit_article_path(@article),
-                  class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm text-white font-semibold leading-6  shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
-      <%= link_to '削除', article_path(@article), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' },
-                                                class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
-    <% end %>
+  <div class="w-5/6 mx-auto max-w-screen-xl">
+    <h1 class="text-3xl mt-5 flex justify-center"><%= @article.title %></h1>
+    <h2 class="text-base mt-5 flex justify-center">作成日：<%= l @article.created_at, format: :long %></h2>
+    <h2 class="text-base flex justify-center">更新日：<%= l @article.updated_at, format: :long %></h2>
+    <h3 class="mt-10 bg-white"><%= render_markdown(@article.body).html_safe %></h3>
+    <div class="flex justify-center gap-7 mb-10 mt-10">
+      <% if @article.user == current_user %>
+        <%= link_to '編集', edit_article_path(@article), class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm text-white font-semibold leading-6  shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
+        <%= link_to '削除', article_path(@article), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' }, class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
+      <% end %>
   </div>
-
- <div class="flex justify-center gap-7 text-xl">
-  <% if @article.published? %>
-    <%= render 'articles/favorite', article: @article, favorite: @favorite %>
-    <%= render 'shared/twitter' %>
+  <div class="flex justify-center gap-7 text-xl">
+    <% if @article.published? %>
+      <%= render 'articles/favorite', article: @article, favorite: @favorite %>
+      <%= render 'shared/twitter' %>
   </div>
-    <%= render 'comments/form', comment: @comment, article: @article %>
       <table class="table">
         <tbody id="comments">
-          <%= render @article.comments, commentfavorites: @commentfavorites %>
+        <%= render 'comments/form', comment: @comment, article: @article %>
+        <%= render @article.comments, commentfavorites: @commentfavorites %>
         </tbody>
       </table>
    <% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,8 +1,12 @@
 <tr id="comment-<%= comment.id %>">
   <td>
     <h3 class="small"><%= comment.user.name %></h3>
-    <p><%= simple_format(comment.body) %></p>
-    <%= render 'comments/commentfavorite', comment:, commentfavorite: @commentfavorite %>
+     <div id="post_comment">
+      <p><%= simple_format(comment.body) %></p>
+     </div>
+      <h5 class="small">投稿日：<%= l comment.created_at, format: :long %></h5>
+      <h5 class="small">最終更新日：<%= l comment.updated_at, format: :long %></h5>
+      <%= render 'comments/commentfavorite', comment:, commentfavorite: @commentfavorite %>
   </td>
     <td class="action">
       <ul class="list-inline justify-content-center" style="float: right;">
@@ -13,8 +17,7 @@
             <% end %>
         </li>
         <li class="list-inline-item">
-          <%= link_to comment_path(comment), class: 'app-link delete-comment-link',
-                                             data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+          <%= link_to comment_path(comment), class: 'app-link delete-comment-link', data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
             <i class="bi bi-trash-fill"></i>
           <% end %>
           <% end %>

--- a/app/views/comments/_favorite.html.erb
+++ b/app/views/comments/_favorite.html.erb
@@ -1,5 +1,4 @@
-<%= link_to comment_commentfavorites_path(comment.id), data: { turbo_method: :post }, id: 'first-comment-favorite',
-                                                       class: 'app-link' do %>
+<%= link_to comment_commentfavorites_path(comment.id), data: { turbo_method: :post }, id: 'first-comment-favorite', class: 'app-link' do %>
   <i class="bi bi-arrow-through-heart"></i>
   <%= comment.commentfavorites.count %>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -2,11 +2,9 @@
   <%= form_with model: comment, url: article_comments_path(article) do |form| %>
     <%= render 'shared/error_messages', object: form.object %>
       <%= form.label :body, 'コメント' %>
-      <%= form.text_area :body, placeholder: 'コメント',
-                                class: 'textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600' %>
+      <%= form.text_area :body, placeholder: 'コメント', class: 'textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600' %>
       <div class="flex justify-center">
-      <%= form.submit '投稿',
-                      class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
+      <%= form.submit '投稿', class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
       </div>
   <% end %>
 </div>

--- a/app/views/comments/edit.turbo_stream.erb
+++ b/app/views/comments/edit.turbo_stream.erb
@@ -1,7 +1,8 @@
-<%= turbo_stream.replace "new_comment" do %>
+<!-----コメント編集する文言を表示------>
+ <%= turbo_stream.replace "post_comment" do %>
   <%= form_with model: @comment do |form| %>
     <%= form.label :body, "コメント"%>
     <%= form.text_area :body, placeholder: 'コメント', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>
-    <%= form.submit "投稿する", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+    <%= form.submit "編集", class: "mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
   <% end %>
 <% end %>

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -1,22 +1,4 @@
-<%= turbo_stream.replace "comments" do %>
-  <td>
-    <h3 class="small"><%= @comment.user.name %></h3>
-    <p><%= simple_format(@comment.body) %></p>
-  </td>
-    <td class="action">
-      <ul class="list-inline justify-content-center" style="float: right;">
-        <li class="list-inline-item">
-        <% if @comment.user == current_user %>
-           <%= link_to edit_comment_path(@comment), class: "app-link edit-comment-link", data: { turbo_stream: true } do %>
-            <i class="bi bi-pencil-fill"></i>
-            <% end %>
-        </li>
-        <li class="list-inline-item">
-          <%= link_to comment_path(@comment), class: "app-link delete-comment-link", data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
-            <i class="bi bi-trash-fill"></i>
-          <% end %>
-          <% end %>
-        </li>
-      </ul>
-    </td>
+<!-----コメント編集した内容が投稿される------>
+<%= turbo_stream.prepend "comments" do %>
+  <%= render 'comments/comment', comment: @comment %>
 <% end %>


### PR DESCRIPTION
## チケットへのリンク
close #117 

## やったこと
- コメントの編集を、テーブル内でできるようにすること
- リロードせずに、その場で連続で編集->投稿、削除ができるように変更
-  コメント編集した内容を投稿した際に、他の投稿が消えない
- コメントの投稿、最終更新日の表示

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- コメントの編集がわかりやすくなった
- リロードせずとも、複数のコメントの編集削除ができる
- コメント編集した内容を投稿した際に、他の投稿が消えないので不安にならない
- コメントの投稿、最終更新日の表示することで、コメントへの信憑性を確認できる

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：問題ないことを確認した

## その他
- 特になし