### PR TITLE
fix #141 コメント編集欄の修正（編集箇所が毎回一番上になってしまう不具合）

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,13 +1,14 @@
 <tr id="comment-<%= comment.id %>">
   <td>
     <h3 class="small"><%= comment.user.name %></h3>
-     <div id="post_comment">
-      <p><%= simple_format(comment.body) %></p>
+     <div id="post_comment-<%= comment.id %>">
+      <p><%= comment.body %></p>
      </div>
       <h5 class="small">投稿日：<%= l comment.created_at, format: :long %></h5>
       <h5 class="small">最終更新日：<%= l comment.updated_at, format: :long %></h5>
       <%= render 'comments/commentfavorite', comment:, commentfavorite: @commentfavorite %>
   </td>
+  </div>
     <td class="action">
       <ul class="list-inline justify-content-center" style="float: right;">
         <li class="list-inline-item">

--- a/app/views/comments/edit.turbo_stream.erb
+++ b/app/views/comments/edit.turbo_stream.erb
@@ -1,5 +1,5 @@
 <!-----コメント編集する文言を表示------>
- <%= turbo_stream.replace "post_comment" do %>
+ <%= turbo_stream.replace "post_comment-#{@comment.id}" do %>
   <%= form_with model: @comment do |form| %>
     <%= form.label :body, "コメント"%>
     <%= form.text_area :body, placeholder: 'コメント', class: "textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600" %>


### PR DESCRIPTION
## チケットへのリンク
close #141 

## やったこと
- コメント編集欄の不具合修正

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- コメントした箇所で、コメントが編集できること

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：コメントした箇所で、コメントが編集できることを確認した

## その他
- 特になし