### PR TITLE
fix #29 GitHub認証

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -4,23 +4,21 @@ class OauthsController < ApplicationController
   skip_before_action :require_login, raise: false
 
   def oauth
-    return redirect_to articles_path, notice: 'ログイン' if logged_in?
-
     login_at(params[:provider])
   end
 
   def callback
     provider = params[:provider]
-    if (@user = login_from(provider))
-      redirect_to articles_path, success: "#{provider.titleize}アカウントでログインしました。"
+    if @user = login_from(provider)
+      redirect_to articles_path, notice: "#{provider.titleize}アカウントでログインしました。"
     else
       begin
         @user = create_from(provider)
         reset_session
         auto_login(@user)
-        redirect_to articles_path, success: "#{provider.titleize}アカウントでログインしました。"
-      rescue StandardError => e
-        Rails.logger.debug e
+        redirect_to articles_path, notice: "#{provider.titleize}アカウントでログインしました。"
+      rescue
+        redirect_to root_path, :notice => "#{provider.titleize}アカウントでログインに失敗しました。"
       end
     end
   end

--- a/app/views/usersessions/new.html.erb
+++ b/app/views/usersessions/new.html.erb
@@ -28,7 +28,7 @@
 
       <%= link_to auth_at_provider_path(provider: :github), class: 'btn btn-light' do %>
         <i class="fab fa-github mr-2"></i>
-          <span class="has-text-weight-medium">Sign in with Github</span>
+          <span class="has-text-weight-medium">Sign in with GitHub</span>
       <% end %>
 
 <h1>パスワードをお忘れの方はこちら</h1>

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,4 +1,0 @@
-github:
-  client_id: <%= ENV.fetch('GITHUB_ID', nil) %>
-  client_secret: <%= ENV.fetch('GITHUB_SECRET', nil) %>
-  callback_url: "https://miniita.onrender.com/oauth/callback?provider=github"


### PR DESCRIPTION
## チケットへのリンク
close #29 

## やったこと
- GitHub認証の本番環境でのログイン確認

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- GitHubログインできるようになった

## できなくなること（ユーザ目線）
- 既に通常ログインしている場合には、GitHub認証は使用できない

## 動作確認
-  ローカル / 本番環境：GitHub認証の本番環境でのログイン確認ができた

## その他
- 特になし