### PR TITLE
fix #125 プレビュー箇所の変更

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -9,7 +9,7 @@ class OauthsController < ApplicationController
 
   def callback
     provider = params[:provider]
-    if @user = login_from(provider)
+    if (@user = login_from(provider))
       redirect_to articles_path, notice: "#{provider.titleize}アカウントでログインしました。"
     else
       begin
@@ -17,7 +17,7 @@ class OauthsController < ApplicationController
         reset_session
         auto_login(@user)
         redirect_to articles_path, notice: "#{provider.titleize}アカウントでログインしました。"
-      rescue
+      rescue StandardError
         redirect_to root_path, notice: "#{provider.titleize}アカウントでのログインに失敗しました。"
       end
     end

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,33 +1,28 @@
 <% content_for :title, page_title('編集') %>
-<div class="mt-10">
-  <div class="w-5/6 mx-auto max-w-screen-xl">
-    <div class="text-xl flex justify-center h-screen w-full">
-      <div class="w-full h-full flex flex-col">
+  <div class="w-5/6 mx-auto max-w-screen-xl mt-10">
+    <div class="w-full">
         <%= form_with model: @article do |form| %>
           <%= form.label :title, 'タイトル', class: ' text-gray-600' %>
           <%= render 'shared/error_messages', object: form.object %>
           <%= form.text_field :title, placeholder: 'タイトル',
-                                      class: 'bg-white text-gray-600 textarea textarea-bordered mb-4 w-full' %>
+                                      class: 'mb-10 bg-white text-gray-600 textarea textarea-bordered w-full' %>
           <br>
           <%= form.label :body, '本文', class: ' text-gray-600' %>
+          <div class="grid grid-cols-1 lg: grid-cols-2 gap-5">
          <%= form.text_area :body, id: 'markdown', placeholder: '本文',
-                                   class: 'textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600' %>
-          <div id="html"></div>
-          <div class="flex justify-center gap-7 mb-10 mt-10">
+                                   class: 'textarea textarea-bordered w-full mb-4 h-full bg-white text-gray-600 h-screen', style: 'overflow:auto;' %>
+          <div id="html"
           <%= form.submit '投稿', name: 'published',
-                                class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
+                                class: 'mb-10 app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
           <% if @article.draft? %>
           <%= form_with model: @article do |form| %>
           <%= form.submit '下書き', name: 'draft',
-                                 class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
-         <% end %>
-          </div>
+                                 class: 'mb-10 app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
+         <% end %>>
         <% end %>
         <% end %>
-      </div>
     </div>
   </div>
-</div>
 <script>
   // idが「markdown」の要素を取得。ユーザーが入力を行ったときに以下の関数が実行される。
   document.getElementById('markdown').addEventListener('input', function () {

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -30,3 +30,4 @@
     <%= paginate @articles %>
   </div>
 </div>
+<%= render 'shared/footer' %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,28 +1,24 @@
 <% content_for :title, page_title('投稿') %>
-<div class="mt-10">
-  <div class="w-5/6 mx-auto max-w-screen-xl w-">
-    <div class="text-xl  flex justify-center h-screen w-full">
-      <div class="w-full h-full flex flex-col ">
+  <div class="w-5/6 mx-auto max-w-screen-xl mt-10">
+    <div class="w-full">
         <%= form_with model: @article do |form| %>
         <%= render 'shared/error_messages', object: form.object %>
-          <%= form.label :title, 'タイトル', class: 'text-gray-600 ' %>
+          <%= form.label :title, 'タイトル', class: 'text-gray-600' %>
           <%= form.text_field :title, placeholder: 'タイトル',
-                                      class: 'bg-white text-gray-600 textarea textarea-bordered mb-4 w-full' %>
+                                      class: 'mb-10 bg-white text-gray-600 textarea textarea-bordered w-full' %>
           <br>
           <%= form.label :body, '本文', class: 'text-gray-600' %>
+          <div class="grid grid-cols-1 lg: grid-cols-2 gap-5">
           <%= form.text_area :body, id: 'markdown', placeholder: '本文',
-                                    class: 'bg-white text-gray-600 textarea textarea-bordered w-full mb-4 h-full' %>
-          <div id="html"></div>
-          <div class="flex justify-center gap-7 mb-10 mt-10">
+                                    class: 'bg-white text-gray-600 textarea textarea-bordered h-screen', style: 'overflow:auto;' %>
+
+          <div id="html"
           <%= form.submit '投稿', name: 'published',
-                                class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
+                                class: 'mb-10 app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
           <%= form.submit '下書き', name: 'draft',
-                                 class: 'app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
-          <% end %>
-      </div>
-    </div>
+                                 class: 'mb-10 app-link rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
+          <% end %>>
   </div>
-</div>
 <script>
   // idが「markdown」の要素を取得。ユーザーが入力を行ったときに以下の関数が実行される。
   document.getElementById('markdown').addEventListener('input', function () {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
     <%= render 'layouts/flash_messages' %>
     <!--------------------------------->
     <%= yield %>
-    <%= render 'shared/footer' %>
+
   </body>
   </div>
 </html>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -1,2 +1,3 @@
 <% content_for :title, page_title('トップ') %>
 トップ画面は本リリース機能も実装してから、作成いたします
+<%= render 'shared/footer' %>


### PR DESCRIPTION
## チケットへのリンク
close #125 

## やったこと
- マークダウン記法が反映される箇所の変更
- テキストエリア内に、スクロールバーを導入

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- マークダウン記法の出力が見やすくなった
- テキストエリアがフッターを突き抜けることがなくなった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：変更されていることを確認した

## その他
- 特になし