### PR TITLE
fix #155 マイページ上のいいね記事、投稿記事欄のクリック範囲拡大

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,10 +5,8 @@ class Article < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  with_options if: :published? do
-    validates :title, presence: true
-    validates :body, presence: true
-  end
+  validates :title, presence: true
+  validates :body, presence: true
 
   # 記事の状態（下書きor投稿済）のステータス
   enum status: { draft: 0, published: 1 }

--- a/app/views/users/my_articles.html.erb
+++ b/app/views/users/my_articles.html.erb
@@ -3,21 +3,22 @@
     <h1>下書き記事 : <%= @draft_articles.count %></h1>
       <ul>
         <% @draft_articles.each do |article| %>
-        <div class="p-4 border rounded-lg mb-3">
-          <li>
-            <%= link_to article.title, article, class: 'app-link' %>
-          </li>
-        </div>
+          <div class="p-4 border rounded-lg mb-3">
+            <%= link_to article_path(article), class: 'app-link' do %>
+              <h2 class="text-xl mt-2 text-gray-600"><%= article.title %></h2>
+            <% end %>
+          </div>
         <% end %>
       </ul>
+
     <h1>投稿済記事 : <%= @published_articles.count %></h1>
       <ul>
         <% @published_articles.each do |article| %>
         <div class="p-4 border rounded-lg mb-3">
-          <li>
-            <%= link_to article.title, article, class: 'app-link' %>
-          </li>
-        </div>
+          <%= link_to article_path(article), class: 'app-link' do %>
+              <h2 class="text-xl mt-2 text-gray-600"><%= article.title %></h2>
+            <% end %>
+          </div>
         <% end %>
       </ul>
 </div>

--- a/app/views/users/my_favorites.html.erb
+++ b/app/views/users/my_favorites.html.erb
@@ -2,57 +2,53 @@
   <div class="w-5/6 mx-auto max-w-screen-xl">
     <h1>いいねした記事</h1>
       <h3>参考になった！<h3>
-      <ul>
-        <% @like_first.each do |favorite| %>
-          <div class="p-4 border rounded-lg mb-3">
-            <li>
-              <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>
-            </li>
-          </div>
-        <% end %>
-      </ul>
-
+        <ul>
+          <% @like_first.each do |favorite| %>
+            <div class="p-4 border rounded-lg mb-3">
+              <%= link_to article_path(favorite.article), class: 'app-link' do %>
+                <h2 class="text-xl mt-2 text-gray-600"><%= favorite.article.title %></h2>
+              <% end %>
+            </div>
+          <% end %>
+        </ul>
       <h3>学びが深まった<h3>
-      <ul>
-        <% @like_second.each do |favorite| %>
-          <div class="p-4 border rounded-lg mb-3">
-            <li>
-              <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>
-            </li>
-          </div>
-        <% end %>
-      </ul>
-
+        <ul>
+          <% @like_second.each do |favorite| %>
+            <div class="p-4 border rounded-lg mb-3">
+              <%= link_to article_path(favorite.article), class: 'app-link' do %>
+                <h2 class="text-xl mt-2 text-gray-600"><%= favorite.article.title %></h2>
+              <% end %>
+            </div>
+          <% end %>
+        </ul>
       <h3>解説が丁寧<h3>
       <ul>
-        <% @like_third.each do |favorite| %>
-          <div class="p-4 border rounded-lg mb-3">
-            <li>
-              <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>
-            </li>
-          </div>
-        <% end %>
-      </ul>
-
+          <% @like_third.each do |favorite| %>
+            <div class="p-4 border rounded-lg mb-3">
+              <%= link_to article_path(favorite.article), class: 'app-link' do %>
+                <h2 class="text-xl mt-2 text-gray-600"><%= favorite.article.title %></h2>
+              <% end %>
+            </div>
+          <% end %>
+        </ul>
       <h3>独自の視点！<h3>
       <ul>
-        <% @like_forth.each do |favorite| %>
-          <div class="p-4 border rounded-lg mb-3">
-            <li>
-              <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>
-            </li>
-          </div>
-        <% end %>
-      </ul>
-
+          <% @like_forth.each do |favorite| %>
+            <div class="p-4 border rounded-lg mb-3">
+              <%= link_to article_path(favorite.article), class: 'app-link' do %>
+                <h2 class="text-xl mt-2 text-gray-600"><%= favorite.article.title %></h2>
+              <% end %>
+            </div>
+          <% end %>
+        </ul>
       <h3>詳細をもっと知りたい<h3>
       <ul>
-        <% @like_fifth.each do |favorite| %>
-          <div class="p-4 border rounded-lg mb-3">
-            <li>
-              <%= link_to favorite.article.title, article_path(favorite.article), class: 'app-link' %>
-            </li>
-          </div>
-        <% end %>
-      </ul>
+          <% @like_fifth.each do |favorite| %>
+            <div class="p-4 border rounded-lg mb-3">
+              <%= link_to article_path(favorite.article), class: 'app-link' do %>
+                <h2 class="text-xl mt-2 text-gray-600"><%= favorite.article.title %></h2>
+              <% end %>
+            </div>
+          <% end %>
+        </ul>
   </div>


### PR DESCRIPTION
## チケットへのリンク
close #155 

## やったこと
- マイページ上の、いいねした記事・投稿済・下書き記事のクリックできる範囲を拡大した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- クリックできる箇所が広がり、UXの向上に繋がると考える

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：いいねした記事・投稿済・下書き記事のクリックできる範囲が拡大したことを確認した

## その他
- 特になし