### PR TITLE
fix #162 通知機能②（コメントへのいいね通知）

### DIFF
--- a/app/controllers/commentfavorites_controller.rb
+++ b/app/controllers/commentfavorites_controller.rb
@@ -5,6 +5,9 @@ class CommentfavoritesController < ApplicationController
     @comment = Comment.find(params[:comment_id])
     @commentfavorite = current_user.commentfavorites.new(comment_id: params[:comment_id])
     @commentfavorite.save
+
+    # コメントいいねの通知
+    @comment.create_notification_commentlike!(current_user)
   end
 
   def destroy

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -9,4 +9,9 @@ class NotificationsController < ApplicationController
       notification.update(checked: true)
     end
   end
+
+  def destroy
+    @notifications = current_user.notifications.destroy_all
+    redirect_to notifications_path
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,4 +11,26 @@ class Comment < ApplicationRecord
   def favorited?(user)
     commentfavorites.exists?(user_id: user.id)
   end
+
+  def create_notification_commentlike!(current_user)
+    # すでにコメントに、いいねされているかの確認
+    temp = Notification.where(['visitor_id = ? and visited_id = ? and comment_id = ? and action = ?', current_user.id,
+                               user_id, id, 'commentlike'])
+
+    # 上記で確認したtempで、いいねされていない場合のみ通知レコードを作成
+    return if temp.present?
+
+    # 現在のユーザーで、相手に送る通知を作成する
+    notification = current_user.active_notifications.new(
+      comment_id: id,
+      visited_id: user_id,
+      action: 'commentlike'
+    )
+
+    # 自分の投稿に対するいいねは、通知済みにする
+    if notification.visitor_id == notification.visited_id
+      notification.checked = true
+    end
+    notification.save if notification.valid?
+  end
 end

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -5,13 +5,18 @@
   <% case notification.action %>
     <% when 'like' then %>
       <%= link_to 'あなたの投稿', notification.article, style: 'font-weight: bold;' %>にいいねしました。
+      <%= time_ago_in_words(notification.created_at).upcase %>
+    <% when 'commentlike' then %>
+      <%= link_to 'あなたのコメント', notification.comment, style: 'font-weight: bold;' %>にいいねしました。
+      <%= time_ago_in_words(notification.created_at).upcase %>
     <% when 'comment' then %>
       <% if notification.article.user_id == visited.id %>
         <%= link_to 'あなたの投稿', notification.article, style: 'font-weight: bold;' %>にコメントしました。
       <% else %>
         <%= link_to article_path(notification.article), class: 'app-link' do %>
-        <a class="font-bold" ><%= notification.article.user.name %>さんの投稿</a>にコメントしました。
-      <%= time_ago_in_words(notification.created_at).upcase %>
-      <% end %>
+          <a class="font-bold" ><%= notification.article.user.name %>さんの投稿</a>にコメントしました。
+        <% end %>
+     <% end %>
+     <%= time_ago_in_words(notification.created_at).upcase %>
   <% end %>
-  <% end %>
+  


### PR DESCRIPTION
## チケットへのリンク
close #162 

## やったこと
- コメントのいいね登録に対して、コメントを書いた人へ通知が入るよう設定した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- コメントした内容にいいねがついた場合に、それを確認することができる

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：問題なし

## その他
- 特になし