### PR TITLE
fix #170 【不具合修正】通知機能②（リンク先）

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -17,7 +17,7 @@ class ArticlesController < ApplicationController
 
   def show
     @article = Article.find(params[:id])
-    @comments = @article.comments.includes(:user).order(created_at: :desc)
+    @comments = @article.comments.includes(:user)
     @comment = Comment.new
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -14,16 +14,17 @@ class Comment < ApplicationRecord
 
   def create_notification_commentlike!(current_user)
     # すでにコメントに、いいねされているかの確認
-    temp = Notification.where(['visitor_id = ? and visited_id = ? and comment_id = ? and action = ?', current_user.id,
-                               user_id, id, 'commentlike'])
+    temp = Notification.where(['visitor_id = ? and visited_id = ? and comment_id = ? and article_id = ? and action = ?', current_user.id,
+                               user_id, id, article_id, 'commentlike'])
 
     # 上記で確認したtempで、いいねされていない場合のみ通知レコードを作成
     return if temp.present?
 
     # 現在のユーザーで、相手に送る通知を作成する
     notification = current_user.active_notifications.new(
-      comment_id: id,
       visited_id: user_id,
+      comment_id: id,
+      article_id:,
       action: 'commentlike'
     )
 

--- a/app/views/commentfavorites/destroy.turbo_stream.erb
+++ b/app/views/commentfavorites/destroy.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace "first-unfavorite-#{@commentfavo.id}" do %>
+<%= turbo_stream.replace "first-unfavorite-#{@commentfavorite.id}" do %>
   <%= render 'comments/favorite', comment: @comment %>
 <% end %>

--- a/app/views/comments/_commentfavorite.html.erb
+++ b/app/views/comments/_commentfavorite.html.erb
@@ -1,6 +1,6 @@
 <% if logged_in? %>
   <% if @comment.favorited?(current_user) %>
-    <%= render 'comments/unfavorite', comment:, commentfavorite: %>
+    <%= render 'comments/unfavorite', comment: %>
   <% else %>
     <%= render 'comments/favorite', comment: %>
   <% end %>

--- a/app/views/comments/_unfavorite.html.erb
+++ b/app/views/comments/_unfavorite.html.erb
@@ -1,4 +1,4 @@
-<%= link_to commentfavorite_path(commentfavorite), data: { turbo_method: :delete }, id: "first-unfavorite-#{comment.id}",
+<%= link_to commentfavorite_path(commentfavorite), data: { turbo_method: :delete }, id: "first-unfavorite-#{commentfavorite.id}",
                                                    class: 'app-link' do %>
   <i class="bi bi-arrow-through-heart-fill"></i>
   <%= comment.commentfavorites.count %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -3,7 +3,7 @@
     <%= render 'comments/form', comment: @comment, article: @comment.article %>
   <% end %>
 <% else %>
-<%= turbo_stream.prepend "comments" do %>
+<%= turbo_stream.append "comments" do %>
     <%= render 'comments/comment', comment: @comment %>
 <% end %>
 <%= turbo_stream.replace "new_comment" do %>

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -1,4 +1,4 @@
 <!-----コメント編集した内容が投稿される------>
-<%= turbo_stream.prepend "comments" do %>
+<%= turbo_stream.append "comments" do %>
   <%= render 'comments/comment', comment: @comment %>
 <% end %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -7,7 +7,7 @@
       <%= link_to 'あなたの投稿', notification.article, style: 'font-weight: bold;' %>にいいねしました。
       <%= time_ago_in_words(notification.created_at).upcase %>
     <% when 'commentlike' then %>
-      <%= link_to 'あなたのコメント', notification.comment, style: 'font-weight: bold;' %>にいいねしました。
+      <%= link_to 'あなたのコメント', notification.comment.article, style: 'font-weight: bold;' %>にいいねしました。
       <%= time_ago_in_words(notification.created_at).upcase %>
     <% when 'comment' then %>
       <% if notification.article.user_id == visited.id %>


### PR DESCRIPTION
## チケットへのリンク
close #170 

## やったこと
- コメントいいねが来た際の、いいねされたコメントへのリンク先が記事詳細画面に遷移するよう変更した

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- コメント投稿者が、どの記事にコメントした内容でいいねがついているのか確認することができるようになった

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：コメントへのいいね先リンクが問題ないことを確認した

## その他
- 特になし