### PR TITLE
fix #192 【UI】ログインページ

### DIFF
--- a/app/views/usersessions/_forgot_password_form.html.erb
+++ b/app/views/usersessions/_forgot_password_form.html.erb
@@ -1,8 +1,9 @@
 <%= form_with url: password_resets_path, local: true, method: :post do |form| %>
-  <div class="field">
-    <%= form.label :email, 'メールアドレス', class: 'block text-sm font-medium leading-6 text-gray-900' %><br>
-    <%= form.text_field :email,
-                        class: 'bg-white rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300' %>
-    <%= form.submit 'パスワードを再設定する' %>
+  <div class="flex items-center space-x-4">
+    <div class="flex-1">
+      <%= form.text_field :email,
+                          class: 'text-xl font-bold pl-4 bg-gray-100 text-gray-600 block w-full rounded-md border-0 py-2.5 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600' %>
+    </div>
+    <%= form.submit '送信', class: "app-link flex-shrink-0 rounded-md bg-blue-900 text-gray-100 px-3 py-1.5 text-sm font-semibold leading-6 shadow-sm hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-800" %>
   </div>
 <% end %>

--- a/app/views/usersessions/new.html.erb
+++ b/app/views/usersessions/new.html.erb
@@ -1,36 +1,36 @@
 <% content_for :title, page_title('ログイン') %>
-<div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
-  <div class="sm:mx-auto sm:w-full sm:max-w-md">
-    <h2 class="mt-6 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">ログイン</h2>
-  </div>
-
-  <div class="mt-3 sm:mx-auto sm:w-full ">
-    <div class="px-6 py-12 sm:rounded-lg sm:px-12">
-      <form class="space-y-6" action="#" method="POST">
-
-        <div>
-          <label for="email" class="block text-sm font-medium leading-6 text-gray-900">メールアドレス</label>
-          <div class="mb-2">
-            <input id="email" name="email" type="email" autocomplete="email" required class="bg-white block w-full rounded-md border-0 py-1.5 text-black shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
-        </div>
-
-        <div>
-          <label for="password" class="block text-sm font-medium leading-6 text-gray-900">パスワード</label>
-          <div class="mb-2">
-            <input id="password" name="password" type="password" autocomplete="current-password" required class="bg-white block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
-          </div>
-        </div>
-
-        <div>
-          <button type="submit" class="mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">ログイン</button>
-        </div>
-      </form>
-
-      <%= link_to auth_at_provider_path(provider: :github), class: 'btn btn-light' do %>
-        <i class="fab fa-github mr-2"></i>
-          <span class="has-text-weight-medium">Sign in with GitHub</span>
-      <% end %>
-
-<h1>パスワードをお忘れの方はこちら</h1>
-<%= render 'forgot_password_form' %>
+<div class="w-5/6 mx-auto max-w-screen-xl mt-20">
+  <h2 class="text-2xl font-bold text-gray-600 mb-10">ログイン</h2>
+  <form class="space-y-6" action="#" method="POST">
+    <div>
+      <label for="email" class="ml-4 text-base font-medium leading-6 text-gray-600">メールアドレス</label>
+      <div class="mb-2">
+        <input id="email" name="email" type="email" required class="text-xl font-bold pl-4 bg-gray-100 text-gray-600 block w-full rounded-md border-0 py-2.5 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
+      </div>
     </div>
+    <div>
+      <label for="password" class="ml-4 text-base font-medium leading-6 text-gray-600">パスワード</label>
+      <div class="mb-2">
+        <input id="password" name="password" type="password" autocomplete="current-password" required class="text-xl font-bold pl-4 bg-gray-100 text-gray-600 block w-full rounded-md border-0 py-2.5 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
+      </div>
+    </div>
+    <div>
+      <button type="submit" class="app-link mt-10 mb-10 flex w-full justify-center rounded-md bg-blue-900 text-gray-100 px-3 py-1.5 text-sm font-semibold leading-6 shadow-sm hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-800">ログイン</button>
+    </div>
+  </form>
+  <p class="font-semibold">---------------------------------------------------------------------------------------------------------------------------------------------------------------------------</p>
+  <div class="flex gap-10">
+    <div class="flex-1">
+      <h2 class="text-2xl font-bold text-gray-600 mb-10"><i class="bi bi-github"></i>GitHubアカウントでログイン</h2>
+      <%= link_to auth_at_provider_path(provider: :github), class: 'app-link mt-10 mb-10 flex w-full justify-center rounded-md bg-blue-900 text-gray-100 px-3 py-1.5 text-sm font-semibold leading-6 shadow-sm hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-800' do %>
+        <i class="fab fa-github mr-2"></i>
+        <span class="has-text-weight-medium">ログイン</span>
+      <% end %>
+    </div>
+    <div class="flex-1">
+      <h1 class="text-2xl font-bold text-gray-600 mb-7">パスワードをお忘れの方はこちら</h1>
+      <%= render 'forgot_password_form' %>
+    </div>
+  </div>
+</div>
+<div class="mb-20"></div>


### PR DESCRIPTION
### 実装内容
- UI調整

 ***
### 使用した資料
- なし

### 特記事項
- パスワードリセットメールを入力する欄と、送信ボタンを並列にする
```
div 要素に flex クラスと items-center クラスを追加して、要素を水平に並べつつ中央揃えにしています。
space-x-4 クラスを使用して、form.text_field と送信ボタンの間に適切な間隔を追加しています。
送信ボタンには flex-shrink-0 クラスを追加して、ボタンが縮小されないようにしています。
```

### エラー対応
