### PR TITLE
fix #197_【UI】パスワードリセット画面

### DIFF
--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :title, page_title('パスワード再設定') %>
-<div class="bg-white flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
-<div class="w-5/6 mx-auto max-w-screen-xl justify-center">
-<h1>パスワードを再設定する</h1>
+<div class="w-5/6 mx-auto max-w-screen-xl mt-20">
+<h1 class="text-3xl font-bold text-gray-600 mb-10">パスワードを再設定する</h1>
 <%= form_for @user, url: password_reset_path(@token), html: { method: :put } do |f| %>
   <% if @user.errors.any? %>
     <div id="error_explanation">
@@ -16,21 +15,23 @@
   <% end %>
 
   <div class="field ">
-    <%= f.label :email, 'メールアドレス', class: 'mt-3block text-sm font-medium leading-6 text-gray-900' %><br>
+    <%= f.label :email, 'メールアドレス', class: 'ml-4 text-base leading-6 text-gray-600' %><br>
+    <div class="text-gray-600 font-bold ml-4 text-xl">
     <%= @user.email %>
+    </div>
   </div>
-  <div class="field">
-    <%= f.label :password, 'パスワード(8文字以上/半角の英数字のみ)', class: 'mt-3block text-sm font-medium leading-6 text-gray-900' %><br>
+  <div class="field mt-10">
+    <%= f.label :password, 'パスワード(8文字以上/半角の英数字のみ)', class: 'ml-4 text-base leading-6 text-gray-600' %><br>
     <%= f.password_field :password, required: true,
-                                    class: 'mb-3 bg-white block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6' %>
+                                    class: 'mb-5 text-xl font-bold pl-4 bg-gray-100 text-gray-600 block w-full rounded-md border-0 py-2.5 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600' %>
   </div>
   <div class="field ">
-    <%= f.label :password_confirmation, 'パスワード確認', class: 'mt-3block text-sm font-medium leading-6 text-gray-900' %><br>
+    <%= f.label :password_confirmation, 'パスワード確認', class: 'mt-20 ml-4 text-base leading-6 text-gray-600' %><br>
     <%= f.password_field :password_confirmation, required: true,
-                                                 class: 'mb-3 bg-white block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6' %>
+                                                 class: 'text-xl font-bold pl-4 bg-gray-100 text-gray-600 block w-full rounded-md border-0 py-2.5 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600' %>
   </div>
   <div class="actions ">
     <%= f.submit '登録',
-                 class: 'mt-10 flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
+                 class: 'app-link mt-10 mb-20 flex w-full justify-center rounded-md bg-blue-900 text-gray-100 px-3 py-1.5 text-sm font-semibold leading-6 shadow-sm hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-800' %>
   </div>
 <% end %>


### PR DESCRIPTION
## チケットへのリンク
close #197 

## やったこと
- パスワードリセット画面のUI調整

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 機能面では変更無し

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：UIが変更されていることを確認

## その他
- 特になし