### PR TITLE
fix #236 【UI】ヘッダーフッターの表示箇所変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,16 +50,18 @@
    <body class="flex flex-col min-h-screen background-image">
     <!------ヘッダーの出し分け------------->
     <% if current_user %>
-     <% unless current_page?(root_path) %>
+     <% unless current_page?(root_path) || current_page?(new_user_path) %>
       <%= render 'shared/after_login_header' %>
      <% end %>
     <% else %>
+    <% unless current_page?(root_path)|| current_page?(new_user_path)  || current_page?(login_path) %>
       <%= render 'shared/before_login_header' %>
+    <% end %>
     <% end %>
     <%= render 'layouts/flash_messages' %>
     <!--------------------------------->
     <%= yield %>
-    <% unless current_page?(root_path) %>
+    <% unless current_page?(root_path)|| current_page?(new_user_path)  || current_page?(login_path) %>
      <%= render 'shared/footer' %>
     <% end %>
   </body>


### PR DESCRIPTION
## チケットへのリンク
close #236 

## やったこと
- ログイン前のトップ画面、ログイン画面、新規登録画面からヘッダーフッターを省いた

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- 機能面では無し

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：UIが変更されていることを確認

## その他
- 特になし