### PR TITLE
本リリース後の不具合修正

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -26,11 +26,15 @@ class PasswordResetsController < ApplicationController
     @user = User.find_by(email: params[:email])
 
     # This line sends an email to the user with instructions on how to reset their password (a url with a random token)
-    @user&.deliver_reset_password_instructions!
-
-    # Tell the user instructions have been sent whether or not email was found.
-    # This is to not leak information to attackers about which emails exist in the system.
-    redirect_to(root_path, notice: 'パスワード再設定メールを送信しました')
+    if @user
+      @user&.deliver_reset_password_instructions!
+      # Tell the user instructions have been sent whether or not email was found.
+      # This is to not leak information to attackers about which emails exist in the system.
+      redirect_to(root_path, notice: 'パスワード再設定メールを送信しました')
+      else
+        flash[:error] = 'メールアドレスを入力してください'
+        render :new, status: :unprocessable_entity
+      end
   end
 
   # This action fires when the user has sent the reset password form.


### PR DESCRIPTION
## やったこと
- パスワードリセット画面で、　入力欄が空欄の場合のバリデーション追加
- テーブル表示

## やらないこと
- 特になし

## できるようになること（ユーザ目線）
- パスワードリセット画面で、　入力欄を空欄のまま送らない

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
-  ローカル / 本番環境：バリデーションがかかることを確認

## その他
- 特になし